### PR TITLE
fix: prevent duplicate "RAG Results" saved search creation

### DIFF
--- a/plugin/src/zotero-rag.js
+++ b/plugin/src/zotero-rag.js
@@ -927,7 +927,6 @@ class ZoteroRAGPlugin {
 	async _ensureRAGResultsSearch(libraryID) {
 		try {
 			const existing = Zotero.Searches.getByLibrary(libraryID)
-				.map(id => Zotero.Searches.get(id))
 				.find(s => s && s.name === 'RAG Results');
 			if (existing) return;
 


### PR DESCRIPTION
Zotero.Searches.getByLibrary() returns Search objects directly, not IDs. The spurious .map(id => Zotero.Searches.get(id)) call passed objects where integers were expected, so the duplicate check always failed and a new saved search was created on every query result.

Closes #32

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>