### PR TITLE
feat: Smart Filing — collection suggestion pane for indexed items (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ For each missing file the tool tries the following strategies in order:
 
 When a file is found it is copied into the correct Zotero storage directory. Items that cannot be recovered can be deleted permanently from the dialog using the **Delete Selected** button.
 
+#### Filing Suggestions
+
+Once a library has been indexed, the backend also maintains a separate layer of *collection vectors* — one embedding per collection computed as the centroid of its member items' title+abstract embeddings. This is independent of the RAG pipeline and does not affect search or question answering.
+
+When you select an item in Zotero, a **Filing Suggestions** section appears in the item details panel (click the folder-with-plus icon in the sidenav). It shows the collections — across all your indexed libraries — whose centroid is most similar to the selected item's embedding, ranked by similarity score.
+
+Each suggestion row displays the full path of the collection (e.g. *My Library / Science / Astrophysics*) and a percentage score. Hovering over a row reveals two action buttons:
+
+- **Copy** — adds the item to the suggested collection while leaving it in its current collections.
+- **Move** — adds the item to the suggested collection and removes it from all existing collections.
+
+After an action the row disappears from the list. The collection vectors for the affected collections are recomputed in the background the next time the library is synced.
+
+Collection vectors are computed automatically as a non-blocking stage at the end of each indexing run. Items not assigned to any collection are excluded (they have no membership signal to learn from). The first time you index a library after upgrading to a version that includes this feature, the full sync runs automatically in the background.
+
 #### Import Open Access Articles from OpenAlex
 
 The script `scripts/openalex_import.py` bulk-imports all open-access articles of a journal (identified by ISSN) from [OpenAlex](https://openalex.org) into a Zotero group library, including PDF attachments.

--- a/README.md
+++ b/README.md
@@ -206,12 +206,16 @@ Once a library has been indexed, the backend also maintains a separate layer of 
 
 When you select an item in Zotero, a **Filing Suggestions** section appears in the item details panel (click the folder-with-plus icon in the sidenav). It shows the collections — across all your indexed libraries — whose centroid is most similar to the selected item's embedding, ranked by similarity score.
 
-Each suggestion row displays the full path of the collection (e.g. *My Library / Science / Astrophysics*) and a percentage score. Hovering over a row reveals two action buttons:
+Each suggestion row displays the full path of the collection (e.g. *My Library / Science / Astrophysics*) and a percentage score. Clicking the path navigates the collections tree to that collection so you can inspect its contents. Hovering over a row reveals two action buttons:
 
 - **Copy** — adds the item to the suggested collection while leaving it in its current collections.
 - **Move** — adds the item to the suggested collection and removes it from all existing collections.
 
 After an action the row disappears from the list. The collection vectors for the affected collections are recomputed in the background the next time the library is synced.
+
+##### Navigating back to the item
+
+Clicking a collection path switches the library view to that collection, which deselects the item and hides the Filing Suggestions pane. To return, use the **← Back** and **Forward →** buttons that appear in the footer of the item pane. These buttons maintain a history of recently viewed items across the entire session, so you can navigate back to the item you were reviewing and continue filing it into other collections.
 
 Collection vectors are computed automatically as a non-blocking stage at the end of each indexing run. Items not assigned to any collection are excluded (they have no membership signal to learn from). The first time you index a library after upgrading to a version that includes this feature, the full sync runs automatically in the background.
 

--- a/backend/api/collections.py
+++ b/backend/api/collections.py
@@ -1,0 +1,144 @@
+"""
+Collections API endpoints for smart filing features.
+
+Provides:
+- GET  /api/collections/vectors/status  — counts of item and collection vectors
+- POST /api/collections/vectors/sync    — full-library sync of item/collection vectors
+- GET  /api/collections/suggest         — suggest collections for an item via vector search
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.db.vector_store import VectorStore
+from backend.dependencies import get_client_api_keys, get_vector_store, make_embedding_service
+from backend.models.collection import (
+    CollectionSuggestion,
+    CollectionVectorsStatus,
+    CollectionVectorSyncRequest,
+)
+from backend.services.collection_vector_service import CollectionVectorService
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/collections/vectors/status", response_model=CollectionVectorsStatus)
+def get_collection_vectors_status(
+    library_id: str,
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    Return counts of pre-computed item and collection vectors for a library.
+
+    Both VectorStore calls are synchronous, so this handler is declared as
+    ``def`` (not ``async def``) so FastAPI runs it in a thread pool.
+
+    Args:
+        library_id: Zotero library ID to query.
+        vector_store: Injected VectorStore singleton.
+
+    Returns:
+        CollectionVectorsStatus with item_vectors_count, collection_vectors_count,
+        and a computed ``computed`` flag (True when collection_vectors_count > 0).
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+
+    item_count = vector_store.count_item_vectors(library_id)
+    coll_count = vector_store.count_collection_vectors(library_id)
+    return CollectionVectorsStatus(
+        library_id=library_id,
+        item_vectors_count=item_count,
+        collection_vectors_count=coll_count,
+        computed=coll_count > 0,
+    )
+
+
+@router.post("/collections/vectors/sync")
+async def sync_collection_vectors(
+    request: CollectionVectorSyncRequest,
+    http_request: Request,
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    Full-library sync: compute item vectors then collection centroids.
+
+    Awaits ``CollectionVectorService.sync_library()``, so the handler is
+    ``async def``.
+
+    Args:
+        request: Sync request containing library_id, collection_map, and
+            optional collection_names.
+        http_request: Raw FastAPI request (used to extract client API keys).
+        vector_store: Injected VectorStore singleton.
+
+    Returns:
+        Stats dict with keys: items_computed, items_skipped,
+        collections_computed, collections_skipped.
+
+    Raises:
+        HTTPException 503: If the vector store is unavailable.
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+
+    client_keys = get_client_api_keys(http_request)
+    embedding_service = make_embedding_service(client_keys)
+    svc = CollectionVectorService(vector_store, embedding_service)
+    return await svc.sync_library(
+        library_id=request.library_id,
+        collection_map=request.collection_map,
+        collection_names=request.collection_names,
+    )
+
+
+@router.get("/collections/suggest", response_model=list[CollectionSuggestion])
+def suggest_collections(
+    library_id: str,
+    item_key: str,
+    limit: int = 5,
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    Suggest collections for an item using pre-computed vectors.
+
+    Retrieves the item's pre-computed vector from ``item_vectors`` and
+    searches ``collection_vectors`` for the nearest neighbours.  All
+    VectorStore calls are synchronous, so this handler is declared as
+    ``def`` (not ``async def``).
+
+    Args:
+        library_id: Zotero library ID.
+        item_key: Zotero item key.
+        limit: Maximum number of suggestions to return (clamped to 20).
+        vector_store: Injected VectorStore singleton.
+
+    Returns:
+        List of CollectionSuggestion objects sorted by descending similarity
+        score.  Returns an empty list (not 404) when no item vector exists.
+
+    Raises:
+        HTTPException 503: If the vector store is unavailable.
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+
+    limit = min(limit, 20)
+
+    item_result = vector_store.get_item_vector(library_id, item_key)
+    if item_result is None:
+        return []
+
+    item_vector, _ = item_result
+    results = vector_store.search_collection_vectors(item_vector, library_id, limit=limit)
+    return [
+        CollectionSuggestion(
+            collection_id=coll_id,
+            collection_name=payload.get("collection_name", ""),
+            library_id=library_id,
+            score=score,
+        )
+        for coll_id, score, payload in results
+    ]

--- a/backend/api/collections.py
+++ b/backend/api/collections.py
@@ -1,4 +1,7 @@
 """
+
+
+
 Provides:
 - GET  /api/collections/vectors/status  - counts of item and collection vectors
 - POST /api/collections/vectors/sync    - full-library sync of item/collection vectors
@@ -90,6 +93,14 @@ async def sync_collection_vectors(
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
 
     try:
+        # DEBUG
+        logger.debug(
+            "sync_collection_vectors: library_id=%s items_in_map=%d unique_collections=%d",
+            request.library_id,
+            len(request.collection_map),
+            len({c for cols in request.collection_map.values() for c in cols}),
+        )
+        # END DEBUG
         client_keys = get_client_api_keys(http_request)
         try:
             embedding_service = make_embedding_service(client_keys)
@@ -142,11 +153,16 @@ def suggest_collections(
 
     try:
         item_result = vector_store.get_item_vector(library_id, item_key)
+        # DEBUG
+        logger.debug("suggest_collections: library_id=%s item_key=%s item_vector_found=%s", library_id, item_key, item_result is not None)  # DEBUG
         if item_result is None:
+            logger.debug("suggest_collections: no item vector for %s/%s - returning []", library_id, item_key)  # DEBUG
             return []
 
         item_vector, _ = item_result
         results = vector_store.search_collection_vectors(item_vector, limit=limit)
+        # DEBUG
+        logger.debug("suggest_collections: collection_vectors search returned %d result(s)", len(results))  # DEBUG
         return [
             CollectionSuggestion(
                 collection_id=coll_id,

--- a/backend/api/collections.py
+++ b/backend/api/collections.py
@@ -9,7 +9,7 @@ Provides:
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query as QueryParam, Request
 
 from backend.db.vector_store import VectorStore
 from backend.dependencies import get_client_api_keys, get_vector_store, make_embedding_service
@@ -17,6 +17,7 @@ from backend.models.collection import (
     CollectionSuggestion,
     CollectionVectorsStatus,
     CollectionVectorSyncRequest,
+    CollectionVectorSyncStats,
 )
 from backend.services.collection_vector_service import CollectionVectorService
 
@@ -46,17 +47,22 @@ def get_collection_vectors_status(
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
 
-    item_count = vector_store.count_item_vectors(library_id)
-    coll_count = vector_store.count_collection_vectors(library_id)
-    return CollectionVectorsStatus(
-        library_id=library_id,
-        item_vectors_count=item_count,
-        collection_vectors_count=coll_count,
-        computed=coll_count > 0,
-    )
+    try:
+        item_count = vector_store.count_item_vectors(library_id)
+        coll_count = vector_store.count_collection_vectors(library_id)
+        return CollectionVectorsStatus(
+            library_id=library_id,
+            item_vectors_count=item_count,
+            collection_vectors_count=coll_count,
+            computed=coll_count > 0,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve collection vectors status: {str(e)}")
 
 
-@router.post("/collections/vectors/sync")
+@router.post("/collections/vectors/sync", response_model=CollectionVectorSyncStats)
 async def sync_collection_vectors(
     request: CollectionVectorSyncRequest,
     http_request: Request,
@@ -75,30 +81,39 @@ async def sync_collection_vectors(
         vector_store: Injected VectorStore singleton.
 
     Returns:
-        Stats dict with keys: items_computed, items_skipped,
+        CollectionVectorSyncStats with keys: items_computed, items_skipped,
         collections_computed, collections_skipped.
 
     Raises:
-        HTTPException 503: If the vector store is unavailable.
+        HTTPException 503: If the vector store or embedding service is unavailable.
+        HTTPException 500: On unexpected errors during sync.
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
 
-    client_keys = get_client_api_keys(http_request)
-    embedding_service = make_embedding_service(client_keys)
-    svc = CollectionVectorService(vector_store, embedding_service)
-    return await svc.sync_library(
-        library_id=request.library_id,
-        collection_map=request.collection_map,
-        collection_names=request.collection_names,
-    )
+    try:
+        client_keys = get_client_api_keys(http_request)
+        try:
+            embedding_service = make_embedding_service(client_keys)
+        except Exception as e:
+            raise HTTPException(status_code=503, detail=f"Embedding service unavailable: {str(e)}")
+        svc = CollectionVectorService(vector_store, embedding_service)
+        return await svc.sync_library(
+            library_id=request.library_id,
+            collection_map=request.collection_map,
+            collection_names=request.collection_names,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to sync collection vectors: {str(e)}")
 
 
 @router.get("/collections/suggest", response_model=list[CollectionSuggestion])
 def suggest_collections(
     library_id: str,
     item_key: str,
-    limit: int = 5,
+    limit: int = QueryParam(default=5, ge=1, le=20),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """
@@ -112,7 +127,7 @@ def suggest_collections(
     Args:
         library_id: Zotero library ID.
         item_key: Zotero item key.
-        limit: Maximum number of suggestions to return (clamped to 20).
+        limit: Maximum number of suggestions to return (1–20, defaults to 5).
         vector_store: Injected VectorStore singleton.
 
     Returns:
@@ -121,24 +136,29 @@ def suggest_collections(
 
     Raises:
         HTTPException 503: If the vector store is unavailable.
+        HTTPException 422: If limit is outside 1–20.
+        HTTPException 500: On unexpected errors.
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
 
-    limit = min(limit, 20)
+    try:
+        item_result = vector_store.get_item_vector(library_id, item_key)
+        if item_result is None:
+            return []
 
-    item_result = vector_store.get_item_vector(library_id, item_key)
-    if item_result is None:
-        return []
-
-    item_vector, _ = item_result
-    results = vector_store.search_collection_vectors(item_vector, library_id, limit=limit)
-    return [
-        CollectionSuggestion(
-            collection_id=coll_id,
-            collection_name=payload.get("collection_name", ""),
-            library_id=library_id,
-            score=score,
-        )
-        for coll_id, score, payload in results
-    ]
+        item_vector, _ = item_result
+        results = vector_store.search_collection_vectors(item_vector, library_id, limit=limit)
+        return [
+            CollectionSuggestion(
+                collection_id=coll_id,
+                collection_name=payload.get("collection_name", ""),
+                library_id=library_id,
+                score=score,
+            )
+            for coll_id, score, payload in results
+        ]
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to suggest collections: {str(e)}")

--- a/backend/api/collections.py
+++ b/backend/api/collections.py
@@ -1,10 +1,8 @@
 """
-Collections API endpoints for smart filing features.
-
 Provides:
-- GET  /api/collections/vectors/status  — counts of item and collection vectors
-- POST /api/collections/vectors/sync    — full-library sync of item/collection vectors
-- GET  /api/collections/suggest         — suggest collections for an item via vector search
+- GET  /api/collections/vectors/status  - counts of item and collection vectors
+- POST /api/collections/vectors/sync    - full-library sync of item/collection vectors
+- GET  /api/collections/suggest         - suggest collections for an item via vector search
 """
 
 import logging
@@ -148,12 +146,12 @@ def suggest_collections(
             return []
 
         item_vector, _ = item_result
-        results = vector_store.search_collection_vectors(item_vector, library_id, limit=limit)
+        results = vector_store.search_collection_vectors(item_vector, limit=limit)
         return [
             CollectionSuggestion(
                 collection_id=coll_id,
                 collection_name=payload.get("collection_name", ""),
-                library_id=library_id,
+                library_id=payload.get("library_id", library_id),
                 score=score,
             )
             for coll_id, score, payload in results

--- a/backend/api/document_upload.py
+++ b/backend/api/document_upload.py
@@ -27,7 +27,7 @@ from threading import Lock
 from typing import Callable, Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.db.vector_store import VectorStore, _extract_lastnames
 from backend.dependencies import get_client_api_keys, get_vector_store, make_embedding_service
@@ -211,6 +211,10 @@ class DocumentUploadResult(BaseModel):
     rate_limit_retries: int = 0
     rate_limit_headers: dict[str, str] | None = None
     error_detail: Optional[str] = None
+    item_vector_pending: bool = Field(
+        default=False,
+        description="True when the item was freshly indexed and its collection vector needs recomputing",
+    )
 
 
 class AsyncUploadResponse(BaseModel):
@@ -400,6 +404,7 @@ async def _execute_upload(
         rate_limit_retries=embedding_service.rate_limit_retries,
         rate_limit_headers=await embedding_service.get_rate_limit_info(),
         error_detail=proc_result.error_detail,
+        item_vector_pending=(api_status == "indexed"),
     )
 
 
@@ -871,6 +876,7 @@ async def upload_and_index_abstract(
         message=f"Indexed {chunks_added} abstract chunks" if chunks_added > 0 else "Abstract already indexed",
         rate_limit_retries=embedding_service.rate_limit_retries,
         rate_limit_headers=await embedding_service.get_rate_limit_info(),
+        item_vector_pending=(status == "indexed"),
     )
 
 

--- a/backend/db/vector_store.py
+++ b/backend/db/vector_store.py
@@ -1314,7 +1314,7 @@ class VectorStore:
         item_key: str,
         vector: list[float],
         collection_ids: list[str],
-        source: Literal["abstract", "chunks"],
+        source: Literal["abstract", "chunks", "title"],
         title: str,
     ) -> str:
         """
@@ -1328,7 +1328,7 @@ class VectorStore:
             item_key: Zotero item key.
             vector: Embedding vector (title+abstract or mean of chunk vectors).
             collection_ids: Zotero collection IDs the item belongs to.
-            source: ``"abstract"`` or ``"chunks"``.
+            source: ``"abstract"``, ``"title"``, or ``"chunks"``.
             title: Item title (for payload readability).
 
         Returns:

--- a/backend/db/vector_store.py
+++ b/backend/db/vector_store.py
@@ -8,6 +8,7 @@ import json
 import logging
 import time
 import warnings
+from datetime import datetime, UTC
 from typing import Optional
 from pathlib import Path
 import uuid
@@ -68,6 +69,8 @@ class VectorStore:
     CHUNKS_COLLECTION = "document_chunks"
     DEDUP_COLLECTION = "deduplication"
     METADATA_COLLECTION = "library_metadata"
+    ITEM_VECTORS_COLLECTION = "item_vectors"
+    COLLECTION_VECTORS_COLLECTION = "collection_vectors"
 
     _CONFIG_FILE = "embedding_config.json"
 
@@ -201,6 +204,30 @@ class VectorStore:
                     field_name="library_id",
                     field_schema="keyword"
                 )
+
+        if self.ITEM_VECTORS_COLLECTION not in collection_names:
+            logger.info(f"Creating collection: {self.ITEM_VECTORS_COLLECTION}")
+            self.client.create_collection(
+                collection_name=self.ITEM_VECTORS_COLLECTION,
+                vectors_config=VectorParams(
+                    size=self.embedding_dim,
+                    distance=self.distance,
+                ),
+            )
+
+        if self.COLLECTION_VECTORS_COLLECTION not in collection_names:
+            logger.info(f"Creating collection: {self.COLLECTION_VECTORS_COLLECTION}")
+            self.client.create_collection(
+                collection_name=self.COLLECTION_VECTORS_COLLECTION,
+                vectors_config=VectorParams(
+                    size=self.embedding_dim,
+                    distance=self.distance,
+                ),
+            )
+
+        # Ensure payload indexes on the new smart-filing collections (idempotent)
+        self._ensure_item_vectors_indexes()
+        self._ensure_collection_vectors_indexes()
 
         # Ensure payload indexes on DEDUP_COLLECTION (idempotent)
         self._ensure_dedup_indexes()
@@ -677,6 +704,34 @@ class VectorStore:
         )
 
         logger.debug(f"Added deduplication record for {record.item_key}")
+
+    def _ensure_item_vectors_indexes(self):
+        """Create keyword payload indexes on ITEM_VECTORS_COLLECTION (idempotent)."""
+        for field in ("item_key", "library_id", "collection_ids"):
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", UserWarning)
+                    self.client.create_payload_index(
+                        collection_name=self.ITEM_VECTORS_COLLECTION,
+                        field_name=field,
+                        field_schema="keyword",
+                    )
+            except Exception:
+                pass  # already exists or local in-memory instance
+
+    def _ensure_collection_vectors_indexes(self):
+        """Create keyword payload indexes on COLLECTION_VECTORS_COLLECTION (idempotent)."""
+        for field in ("collection_id", "library_id"):
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", UserWarning)
+                    self.client.create_payload_index(
+                        collection_name=self.COLLECTION_VECTORS_COLLECTION,
+                        field_name=field,
+                        field_schema="keyword",
+                    )
+            except Exception:
+                pass  # already exists or local in-memory instance
 
     def _ensure_dedup_indexes(self):
         """Create payload index on content_hash in DEDUP_COLLECTION (idempotent)."""
@@ -1244,6 +1299,400 @@ class VectorStore:
         except Exception as e:
             logger.warning(f"Error computing size for library {library_id}: {e}")
         return total
+
+    # ---------------------------------------------------------------------------
+    # Item Vectors Methods (smart filing — one vector per Zotero item)
+    # ---------------------------------------------------------------------------
+
+    def upsert_item_vector(
+        self,
+        library_id: str,
+        item_key: str,
+        vector: list[float],
+        collection_ids: list[str],
+        source: str,
+        title: str,
+    ) -> str:
+        """
+        Upsert a single item vector.
+
+        Uses a deterministic UUID derived from (library_id, item_key) so that
+        repeated calls overwrite the existing point rather than duplicating it.
+
+        Args:
+            library_id: Zotero library ID.
+            item_key: Zotero item key.
+            vector: Embedding vector (title+abstract or mean of chunk vectors).
+            collection_ids: Zotero collection IDs the item belongs to.
+            source: ``"abstract"`` or ``"chunks"``.
+            title: Item title (for payload readability).
+
+        Returns:
+            UUID of the upserted point.
+        """
+        namespace = uuid.UUID("abcdef12-1234-5678-abcd-abcdef123456")
+        point_id = str(uuid.uuid5(namespace, f"{library_id}:{item_key}"))
+        point = PointStruct(
+            id=point_id,
+            vector=vector,
+            payload={
+                "item_key": item_key,
+                "library_id": library_id,
+                "collection_ids": collection_ids,
+                "source": source,
+                "title": title,
+                "computed_at": datetime.now(UTC).isoformat(),
+                "schema_version": 1,
+            },
+        )
+        self.client.upsert(
+            collection_name=self.ITEM_VECTORS_COLLECTION,
+            points=[point],
+        )
+        logger.debug(f"Upserted item vector for {library_id}/{item_key}")
+        return point_id
+
+    def get_item_vector(
+        self,
+        library_id: str,
+        item_key: str,
+    ) -> Optional[tuple[list[float], dict]]:
+        """
+        Retrieve the item vector and payload for a single item.
+
+        Args:
+            library_id: Zotero library ID.
+            item_key: Zotero item key.
+
+        Returns:
+            ``(vector, payload)`` tuple, or ``None`` if not found.
+        """
+        namespace = uuid.UUID("abcdef12-1234-5678-abcd-abcdef123456")
+        point_id = str(uuid.uuid5(namespace, f"{library_id}:{item_key}"))
+        points = self.client.retrieve(
+            collection_name=self.ITEM_VECTORS_COLLECTION,
+            ids=[point_id],
+            with_vectors=True,
+        )
+        if not points:
+            return None
+        p = points[0]
+        vector = p.vector if isinstance(p.vector, list) else list(p.vector)
+        return vector, p.payload
+
+    def get_item_vectors_for_library(
+        self,
+        library_id: str,
+    ) -> list[tuple[str, list[float], list[str]]]:
+        """
+        Return all item vectors for a library.
+
+        Args:
+            library_id: Zotero library ID.
+
+        Returns:
+            List of ``(item_key, vector, collection_ids)`` tuples.
+        """
+        results: list[tuple[str, list[float], list[str]]] = []
+        offset = None
+        while True:
+            batch, next_offset = self.client.scroll(
+                collection_name=self.ITEM_VECTORS_COLLECTION,
+                scroll_filter=Filter(must=[
+                    FieldCondition(key="library_id", match=MatchValue(value=library_id)),
+                ]),
+                limit=500,
+                offset=offset,
+                with_payload=True,
+                with_vectors=True,
+            )
+            for point in batch:
+                p = point.payload
+                vec = point.vector if isinstance(point.vector, list) else list(point.vector)
+                results.append((p["item_key"], vec, p.get("collection_ids", [])))
+            if next_offset is None:
+                break
+            offset = next_offset
+        return results
+
+    def get_chunk_vectors_for_item(
+        self,
+        library_id: str,
+        item_key: str,
+    ) -> list[list[float]]:
+        """
+        Return all chunk vectors for an item from the ``document_chunks`` collection.
+
+        Used as an A1 fallback when no title+abstract embedding is available.
+
+        Args:
+            library_id: Zotero library ID.
+            item_key: Zotero item key.
+
+        Returns:
+            List of embedding vectors (one per chunk).
+        """
+        vectors: list[list[float]] = []
+        offset = None
+        while True:
+            batch, next_offset = self.client.scroll(
+                collection_name=self.CHUNKS_COLLECTION,
+                scroll_filter=Filter(must=[
+                    FieldCondition(key="library_id", match=MatchValue(value=library_id)),
+                    FieldCondition(key="item_key", match=MatchValue(value=item_key)),
+                ]),
+                limit=500,
+                offset=offset,
+                with_payload=False,
+                with_vectors=True,
+            )
+            for point in batch:
+                vec = point.vector if isinstance(point.vector, list) else list(point.vector)
+                vectors.append(vec)
+            if next_offset is None:
+                break
+            offset = next_offset
+        return vectors
+
+    def count_item_vectors(self, library_id: str) -> int:
+        """
+        Count item vectors for a library.
+
+        Args:
+            library_id: Zotero library ID.
+
+        Returns:
+            Number of item vector points.
+        """
+        try:
+            result = self.client.count(
+                collection_name=self.ITEM_VECTORS_COLLECTION,
+                count_filter=Filter(must=[
+                    FieldCondition(key="library_id", match=MatchValue(value=library_id)),
+                ]),
+            )
+            return result.count
+        except Exception as e:
+            logger.warning(f"Error counting item vectors for library {library_id}: {e}")
+            return 0
+
+    def delete_item_vector(self, library_id: str, item_key: str) -> int:
+        """
+        Delete the item vector for a single item.
+
+        Args:
+            library_id: Zotero library ID.
+            item_key: Zotero item key.
+
+        Returns:
+            Number of points deleted (0 or 1).
+        """
+        count_before = self.count_item_vectors(library_id)
+        namespace = uuid.UUID("abcdef12-1234-5678-abcd-abcdef123456")
+        point_id = str(uuid.uuid5(namespace, f"{library_id}:{item_key}"))
+        points = self.client.retrieve(
+            collection_name=self.ITEM_VECTORS_COLLECTION,
+            ids=[point_id],
+            with_vectors=False,
+        )
+        if not points:
+            return 0
+        self.client.delete(
+            collection_name=self.ITEM_VECTORS_COLLECTION,
+            points_selector=[point_id],
+        )
+        count_after = self.count_item_vectors(library_id)
+        deleted = count_before - count_after
+        logger.debug(f"Deleted {deleted} item vector(s) for {library_id}/{item_key}")
+        return deleted
+
+    # ---------------------------------------------------------------------------
+    # Collection Vectors Methods (smart filing — one vector per Zotero collection)
+    # ---------------------------------------------------------------------------
+
+    def upsert_collection_vector(
+        self,
+        library_id: str,
+        collection_id: str,
+        collection_name: str,
+        vector: list[float],
+        item_count: int,
+    ) -> str:
+        """
+        Upsert a collection vector (mean of member item vectors).
+
+        Uses a deterministic UUID derived from (library_id, collection_id).
+
+        Args:
+            library_id: Zotero library ID.
+            collection_id: Zotero collection ID.
+            collection_name: Human-readable collection name.
+            vector: Mean embedding of member items.
+            item_count: Number of items in the collection.
+
+        Returns:
+            UUID of the upserted point.
+        """
+        namespace = uuid.UUID("fedcba98-8765-4321-fedc-fedcba987654")
+        point_id = str(uuid.uuid5(namespace, f"{library_id}:{collection_id}"))
+        point = PointStruct(
+            id=point_id,
+            vector=vector,
+            payload={
+                "collection_id": collection_id,
+                "library_id": library_id,
+                "collection_name": collection_name,
+                "item_count": item_count,
+                "computed_at": datetime.now(UTC).isoformat(),
+                "schema_version": 1,
+            },
+        )
+        self.client.upsert(
+            collection_name=self.COLLECTION_VECTORS_COLLECTION,
+            points=[point],
+        )
+        logger.debug(f"Upserted collection vector for {library_id}/{collection_id}")
+        return point_id
+
+    def get_collection_vector(
+        self,
+        library_id: str,
+        collection_id: str,
+    ) -> Optional[tuple[list[float], dict]]:
+        """
+        Retrieve the vector and payload for a single collection.
+
+        Args:
+            library_id: Zotero library ID.
+            collection_id: Zotero collection ID.
+
+        Returns:
+            ``(vector, payload)`` tuple, or ``None`` if not found.
+        """
+        namespace = uuid.UUID("fedcba98-8765-4321-fedc-fedcba987654")
+        point_id = str(uuid.uuid5(namespace, f"{library_id}:{collection_id}"))
+        points = self.client.retrieve(
+            collection_name=self.COLLECTION_VECTORS_COLLECTION,
+            ids=[point_id],
+            with_vectors=True,
+        )
+        if not points:
+            return None
+        p = points[0]
+        vector = p.vector if isinstance(p.vector, list) else list(p.vector)
+        return vector, p.payload
+
+    def get_all_collection_vectors(
+        self,
+        library_id: str,
+    ) -> list[tuple[str, list[float], dict]]:
+        """
+        Return all collection vectors for a library.
+
+        Args:
+            library_id: Zotero library ID.
+
+        Returns:
+            List of ``(collection_id, vector, payload)`` tuples.
+        """
+        results: list[tuple[str, list[float], dict]] = []
+        offset = None
+        while True:
+            batch, next_offset = self.client.scroll(
+                collection_name=self.COLLECTION_VECTORS_COLLECTION,
+                scroll_filter=Filter(must=[
+                    FieldCondition(key="library_id", match=MatchValue(value=library_id)),
+                ]),
+                limit=500,
+                offset=offset,
+                with_payload=True,
+                with_vectors=True,
+            )
+            for point in batch:
+                vec = point.vector if isinstance(point.vector, list) else list(point.vector)
+                results.append((point.payload["collection_id"], vec, point.payload))
+            if next_offset is None:
+                break
+            offset = next_offset
+        return results
+
+    def search_collection_vectors(
+        self,
+        query_vector: list[float],
+        library_id: str,
+        limit: int = 5,
+    ) -> list[tuple[str, float, dict]]:
+        """
+        Find the most similar collections to a query vector.
+
+        Args:
+            query_vector: Query embedding (e.g. title+abstract of an item).
+            library_id: Restrict search to this library.
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of ``(collection_id, score, payload)`` tuples sorted by score descending.
+        """
+        query_filter = Filter(must=[
+            FieldCondition(key="library_id", match=MatchValue(value=library_id)),
+        ])
+        hits = self.client.query_points(
+            collection_name=self.COLLECTION_VECTORS_COLLECTION,
+            query=query_vector,
+            limit=limit,
+            query_filter=query_filter,
+            with_payload=True,
+        ).points
+        return [(h.payload["collection_id"], h.score, h.payload) for h in hits]
+
+    def count_collection_vectors(self, library_id: str) -> int:
+        """
+        Count collection vectors for a library.
+
+        Args:
+            library_id: Zotero library ID.
+
+        Returns:
+            Number of collection vector points.
+        """
+        try:
+            result = self.client.count(
+                collection_name=self.COLLECTION_VECTORS_COLLECTION,
+                count_filter=Filter(must=[
+                    FieldCondition(key="library_id", match=MatchValue(value=library_id)),
+                ]),
+            )
+            return result.count
+        except Exception as e:
+            logger.warning(f"Error counting collection vectors for library {library_id}: {e}")
+            return 0
+
+    def delete_collection_vector(self, library_id: str, collection_id: str) -> int:
+        """
+        Delete the vector for a single collection.
+
+        Args:
+            library_id: Zotero library ID.
+            collection_id: Zotero collection ID.
+
+        Returns:
+            Number of points deleted (0 or 1).
+        """
+        namespace = uuid.UUID("fedcba98-8765-4321-fedc-fedcba987654")
+        point_id = str(uuid.uuid5(namespace, f"{library_id}:{collection_id}"))
+        points = self.client.retrieve(
+            collection_name=self.COLLECTION_VECTORS_COLLECTION,
+            ids=[point_id],
+            with_vectors=False,
+        )
+        if not points:
+            return 0
+        self.client.delete(
+            collection_name=self.COLLECTION_VECTORS_COLLECTION,
+            points_selector=[point_id],
+        )
+        logger.debug(f"Deleted collection vector for {library_id}/{collection_id}")
+        return 1
 
     def close(self):
         """

--- a/backend/db/vector_store.py
+++ b/backend/db/vector_store.py
@@ -9,7 +9,7 @@ import logging
 import time
 import warnings
 from datetime import datetime, UTC
-from typing import Optional
+from typing import Literal, Optional
 from pathlib import Path
 import uuid
 
@@ -71,6 +71,10 @@ class VectorStore:
     METADATA_COLLECTION = "library_metadata"
     ITEM_VECTORS_COLLECTION = "item_vectors"
     COLLECTION_VECTORS_COLLECTION = "collection_vectors"
+
+    # Stable namespaces for deterministic UUID5 point IDs
+    _ITEM_VECTOR_NS = uuid.UUID("abcdef12-1234-5678-abcd-abcdef123456")
+    _COLLECTION_VECTOR_NS = uuid.UUID("fedcba98-8765-4321-fedc-fedcba987654")
 
     _CONFIG_FILE = "embedding_config.json"
 
@@ -1310,7 +1314,7 @@ class VectorStore:
         item_key: str,
         vector: list[float],
         collection_ids: list[str],
-        source: str,
+        source: Literal["abstract", "chunks"],
         title: str,
     ) -> str:
         """
@@ -1330,8 +1334,7 @@ class VectorStore:
         Returns:
             UUID of the upserted point.
         """
-        namespace = uuid.UUID("abcdef12-1234-5678-abcd-abcdef123456")
-        point_id = str(uuid.uuid5(namespace, f"{library_id}:{item_key}"))
+        point_id = str(uuid.uuid5(self._ITEM_VECTOR_NS, f"{library_id}:{item_key}"))
         point = PointStruct(
             id=point_id,
             vector=vector,
@@ -1367,8 +1370,7 @@ class VectorStore:
         Returns:
             ``(vector, payload)`` tuple, or ``None`` if not found.
         """
-        namespace = uuid.UUID("abcdef12-1234-5678-abcd-abcdef123456")
-        point_id = str(uuid.uuid5(namespace, f"{library_id}:{item_key}"))
+        point_id = str(uuid.uuid5(self._ITEM_VECTOR_NS, f"{library_id}:{item_key}"))
         points = self.client.retrieve(
             collection_name=self.ITEM_VECTORS_COLLECTION,
             ids=[point_id],
@@ -1487,24 +1489,15 @@ class VectorStore:
         Returns:
             Number of points deleted (0 or 1).
         """
-        count_before = self.count_item_vectors(library_id)
-        namespace = uuid.UUID("abcdef12-1234-5678-abcd-abcdef123456")
-        point_id = str(uuid.uuid5(namespace, f"{library_id}:{item_key}"))
-        points = self.client.retrieve(
-            collection_name=self.ITEM_VECTORS_COLLECTION,
-            ids=[point_id],
-            with_vectors=False,
-        )
-        if not points:
+        if self.get_item_vector(library_id, item_key) is None:
             return 0
+        point_id = str(uuid.uuid5(self._ITEM_VECTOR_NS, f"{library_id}:{item_key}"))
         self.client.delete(
             collection_name=self.ITEM_VECTORS_COLLECTION,
             points_selector=[point_id],
         )
-        count_after = self.count_item_vectors(library_id)
-        deleted = count_before - count_after
-        logger.debug(f"Deleted {deleted} item vector(s) for {library_id}/{item_key}")
-        return deleted
+        logger.debug(f"Deleted item vector for {library_id}/{item_key}")
+        return 1
 
     # ---------------------------------------------------------------------------
     # Collection Vectors Methods (smart filing — one vector per Zotero collection)
@@ -1533,8 +1526,7 @@ class VectorStore:
         Returns:
             UUID of the upserted point.
         """
-        namespace = uuid.UUID("fedcba98-8765-4321-fedc-fedcba987654")
-        point_id = str(uuid.uuid5(namespace, f"{library_id}:{collection_id}"))
+        point_id = str(uuid.uuid5(self._COLLECTION_VECTOR_NS, f"{library_id}:{collection_id}"))
         point = PointStruct(
             id=point_id,
             vector=vector,
@@ -1569,8 +1561,7 @@ class VectorStore:
         Returns:
             ``(vector, payload)`` tuple, or ``None`` if not found.
         """
-        namespace = uuid.UUID("fedcba98-8765-4321-fedc-fedcba987654")
-        point_id = str(uuid.uuid5(namespace, f"{library_id}:{collection_id}"))
+        point_id = str(uuid.uuid5(self._COLLECTION_VECTOR_NS, f"{library_id}:{collection_id}"))
         points = self.client.retrieve(
             collection_name=self.COLLECTION_VECTORS_COLLECTION,
             ids=[point_id],
@@ -1678,8 +1669,7 @@ class VectorStore:
         Returns:
             Number of points deleted (0 or 1).
         """
-        namespace = uuid.UUID("fedcba98-8765-4321-fedc-fedcba987654")
-        point_id = str(uuid.uuid5(namespace, f"{library_id}:{collection_id}"))
+        point_id = str(uuid.uuid5(self._COLLECTION_VECTOR_NS, f"{library_id}:{collection_id}"))
         points = self.client.retrieve(
             collection_name=self.COLLECTION_VECTORS_COLLECTION,
             ids=[point_id],
@@ -1693,6 +1683,56 @@ class VectorStore:
         )
         logger.debug(f"Deleted collection vector for {library_id}/{collection_id}")
         return 1
+
+    def delete_library_item_vectors(self, library_id: str) -> int:
+        """
+        Delete all item vectors for a specific library.
+
+        Args:
+            library_id: Zotero library ID.
+
+        Returns:
+            Number of item vectors deleted.
+        """
+        count_before = self.count_item_vectors(library_id)
+        self.client.delete(
+            collection_name=self.ITEM_VECTORS_COLLECTION,
+            points_selector=Filter(
+                must=[
+                    FieldCondition(
+                        key="library_id",
+                        match=MatchValue(value=library_id),
+                    )
+                ]
+            ),
+        )
+        logger.info(f"Deleted {count_before} item vectors for library {library_id}")
+        return count_before
+
+    def delete_library_collection_vectors(self, library_id: str) -> int:
+        """
+        Delete all collection vectors for a specific library.
+
+        Args:
+            library_id: Zotero library ID.
+
+        Returns:
+            Number of collection vectors deleted.
+        """
+        count_before = self.count_collection_vectors(library_id)
+        self.client.delete(
+            collection_name=self.COLLECTION_VECTORS_COLLECTION,
+            points_selector=Filter(
+                must=[
+                    FieldCondition(
+                        key="library_id",
+                        match=MatchValue(value=library_id),
+                    )
+                ]
+            ),
+        )
+        logger.info(f"Deleted {count_before} collection vectors for library {library_id}")
+        return count_before
 
     def close(self):
         """

--- a/backend/db/vector_store.py
+++ b/backend/db/vector_store.py
@@ -1610,7 +1610,7 @@ class VectorStore:
     def search_collection_vectors(
         self,
         query_vector: list[float],
-        library_id: str,
+        library_id: Optional[str] = None,
         limit: int = 5,
     ) -> list[tuple[str, float, dict]]:
         """
@@ -1618,15 +1618,18 @@ class VectorStore:
 
         Args:
             query_vector: Query embedding (e.g. title+abstract of an item).
-            library_id: Restrict search to this library.
+            library_id: If provided, restrict search to this library.
+                        If None, search across all libraries.
             limit: Maximum number of results to return.
 
         Returns:
             List of ``(collection_id, score, payload)`` tuples sorted by score descending.
         """
-        query_filter = Filter(must=[
-            FieldCondition(key="library_id", match=MatchValue(value=library_id)),
-        ])
+        query_filter = (
+            Filter(must=[FieldCondition(key="library_id", match=MatchValue(value=library_id))])
+            if library_id is not None
+            else None
+        )
         hits = self.client.query_points(
             collection_name=self.COLLECTION_VECTORS_COLLECTION,
             query=query_vector,

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,7 +14,7 @@ from backend.__version__ import __version__
 from backend.config.settings import get_settings
 from backend.db.vector_store import VectorStore
 from backend.dependencies import make_vector_store
-from backend.api import config, libraries, indexing, query, document_upload, registration, rate_limits, public_query
+from backend.api import config, libraries, indexing, query, document_upload, registration, rate_limits, public_query, collections as collections_api
 from backend.api.document_upload import load_item_cache, save_item_cache
 
 # Get settings to access log configuration
@@ -186,6 +186,7 @@ app.include_router(document_upload.router, prefix="/api", tags=["document-upload
 app.include_router(registration.router, prefix="/api", tags=["registration"])
 app.include_router(rate_limits.router, prefix="/api", tags=["rate-limits"])
 app.include_router(public_query.router, tags=["public"])
+app.include_router(collections_api.router, prefix="/api", tags=["collections"])
 
 
 @app.get("/")

--- a/backend/models/collection.py
+++ b/backend/models/collection.py
@@ -1,0 +1,33 @@
+"""
+Data models for collection-based smart filing features.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class CollectionSuggestion(BaseModel):
+    """A suggested Zotero collection for a given item, with a similarity score."""
+
+    collection_id: str
+    collection_name: str
+    library_id: str
+    score: float  # cosine similarity 0..1
+
+
+class CollectionVectorsStatus(BaseModel):
+    """Status of pre-computed item and collection vectors for a library."""
+
+    library_id: str
+    item_vectors_count: int
+    collection_vectors_count: int
+    computed: bool  # True if collection_vectors_count > 0
+
+
+class CollectionVectorSyncRequest(BaseModel):
+    """Request payload for syncing item/collection vectors from the Zotero plugin."""
+
+    library_id: str
+    # Maps item_key -> list of collection_ids the item belongs to
+    collection_map: dict[str, list[str]]
+    # Maps collection_id -> human-readable collection name
+    collection_names: dict[str, str] = Field(default_factory=dict)

--- a/backend/models/collection.py
+++ b/backend/models/collection.py
@@ -31,3 +31,12 @@ class CollectionVectorSyncRequest(BaseModel):
     collection_map: dict[str, list[str]]
     # Maps collection_id -> human-readable collection name
     collection_names: dict[str, str] = Field(default_factory=dict)
+
+
+class CollectionVectorSyncStats(BaseModel):
+    """Stats returned after syncing item/collection vectors."""
+
+    items_computed: int
+    items_skipped: int
+    collections_computed: int
+    collections_skipped: int

--- a/backend/services/collection_vector_service.py
+++ b/backend/services/collection_vector_service.py
@@ -92,10 +92,13 @@ class CollectionVectorService:
         clean_abstract = (abstract or "").strip()
         clean_title = (title or "").strip()
 
-        if clean_abstract and len(clean_abstract) >= self.min_abstract_chars:
+        has_full_abstract = bool(clean_abstract and len(clean_abstract) >= self.min_abstract_chars)
+        if has_full_abstract:
             embed_text = f"{clean_title} {clean_abstract}".strip()
+            a2_source = "abstract"
         else:
             embed_text = clean_title
+            a2_source = "title"
 
         vector: Optional[list[float]] = None
         source: Optional[str] = None
@@ -104,7 +107,7 @@ class CollectionVectorService:
             vector = await self.embedding_service.embed_text(embed_text)
             # Treat an all-zero or empty result as unusable
             if vector and any(v != 0.0 for v in vector):
-                source = "abstract"
+                source = a2_source
             else:
                 vector = None
 
@@ -312,6 +315,15 @@ class CollectionVectorService:
             ``True`` if the item vector was successfully computed and stored,
             ``False`` if no data was available (item was skipped).
         """
+        # Read the item's existing collection_ids before overwriting, so that
+        # centroids for collections the item is *leaving* are also refreshed.
+        old_collection_ids: list[str] = []
+        existing_item = await asyncio.to_thread(
+            self.vector_store.get_item_vector, library_id, item_key
+        )
+        if existing_item is not None:
+            old_collection_ids = existing_item[1].get("collection_ids", [])
+
         result = await self.compute_item_vector(
             library_id=library_id,
             item_key=item_key,
@@ -322,19 +334,19 @@ class CollectionVectorService:
         if result is None:
             return False
 
-        # Refresh centroids for all affected collections.
-        if collection_ids:
+        # Refresh centroids for all affected collections — union of old and new.
+        all_affected = list(set(collection_ids) | set(old_collection_ids))
+        if all_affected:
             all_item_vectors = await asyncio.to_thread(
                 self.vector_store.get_item_vectors_for_library, library_id
             )
-            for collection_id in collection_ids:
+            for collection_id in all_affected:
                 # Attempt to look up a stored name; fall back to the ID itself.
-                existing = await asyncio.to_thread(
+                existing_col = await asyncio.to_thread(
                     self.vector_store.get_collection_vector, library_id, collection_id
                 )
-                if existing is not None:
-                    _vec, payload = existing
-                    cname = payload.get("collection_name", collection_id)
+                if existing_col is not None:
+                    cname = existing_col[1].get("collection_name", collection_id)
                 else:
                     cname = collection_id
                 await asyncio.to_thread(

--- a/backend/services/collection_vector_service.py
+++ b/backend/services/collection_vector_service.py
@@ -1,0 +1,344 @@
+"""
+Collection vector service for smart filing.
+
+Computes per-item vectors (A2: title+abstract, falling back to A1: mean of chunk vectors)
+and per-collection centroid vectors (mean of member item vectors).
+
+Provides full-library batch sync and incremental per-item update.
+"""
+
+import asyncio
+import logging
+from typing import Callable, Optional
+
+import numpy as np
+
+from backend.db.vector_store import VectorStore
+from backend.services.embeddings import EmbeddingService
+
+logger = logging.getLogger(__name__)
+
+
+def _mean_vector(vectors: list[list[float]]) -> list[float]:
+    """Compute element-wise mean of a list of equal-length vectors using numpy."""
+    arr = np.array(vectors, dtype=np.float64)
+    return arr.mean(axis=0).tolist()
+
+
+class CollectionVectorService:
+    """
+    Service for computing and storing item and collection embedding vectors.
+
+    Item vectors are computed either from title+abstract (A2, primary) or as the
+    arithmetic mean of all indexed chunk vectors (A1, fallback).
+
+    Collection vectors are computed as the arithmetic mean of all member item vectors.
+    """
+
+    def __init__(
+        self,
+        vector_store: VectorStore,
+        embedding_service: EmbeddingService,
+        min_abstract_chars: int = 50,
+    ):
+        """
+        Initialise the service.
+
+        Args:
+            vector_store: VectorStore instance for reading/writing vectors.
+            embedding_service: EmbeddingService used for A2 text embeddings.
+            min_abstract_chars: Minimum character count for an abstract to be
+                considered usable in the A2 path.  Abstracts shorter than this
+                threshold trigger the A1 (chunk-mean) fallback.
+        """
+        self.vector_store = vector_store
+        self.embedding_service = embedding_service
+        self.min_abstract_chars = min_abstract_chars
+
+    # ------------------------------------------------------------------
+    # Item vector computation
+    # ------------------------------------------------------------------
+
+    async def compute_item_vector(
+        self,
+        library_id: str,
+        item_key: str,
+        title: str,
+        abstract: str,
+        collection_ids: list[str],
+    ) -> Optional[str]:
+        """
+        Compute and persist an item vector.
+
+        Strategy:
+        1. A2 (primary): embed ``title + " " + abstract``.  If the abstract is
+           too short (< ``min_abstract_chars``), embed only the title.
+        2. A1 (fallback): compute the mean of all chunk vectors stored for the
+           item in Qdrant.  Applied when the A2 text is empty or when the
+           embedding service returns an empty vector.
+
+        Args:
+            library_id: Zotero library ID.
+            item_key: Zotero item key.
+            title: Item title (may be empty but should not be None).
+            abstract: Item abstract (may be empty).
+            collection_ids: Collection IDs the item belongs to.
+
+        Returns:
+            Qdrant point UUID string if the vector was stored, ``None`` if no
+            data was available to produce a vector.
+        """
+        # --- A2: title + abstract ---
+        clean_abstract = (abstract or "").strip()
+        clean_title = (title or "").strip()
+
+        if clean_abstract and len(clean_abstract) >= self.min_abstract_chars:
+            embed_text = f"{clean_title} {clean_abstract}".strip()
+        else:
+            embed_text = clean_title
+
+        vector: Optional[list[float]] = None
+        source: Optional[str] = None
+
+        if embed_text:
+            vector = await self.embedding_service.embed_text(embed_text)
+            # Treat an all-zero or empty result as unusable
+            if vector and any(v != 0.0 for v in vector):
+                source = "abstract"
+            else:
+                vector = None
+
+        # --- A1 fallback: mean-pool chunk vectors ---
+        if vector is None:
+            chunk_vectors = await asyncio.to_thread(
+                self.vector_store.get_chunk_vectors_for_item, library_id, item_key
+            )
+            if not chunk_vectors:
+                logger.debug(
+                    "No text or chunks available for item %s/%s — skipping.",
+                    library_id,
+                    item_key,
+                )
+                return None
+            vector = _mean_vector(chunk_vectors)
+            source = "chunks"
+
+        point_id = await asyncio.to_thread(
+            self.vector_store.upsert_item_vector,
+            library_id,
+            item_key,
+            vector,
+            collection_ids,
+            source,
+            clean_title or item_key,
+        )
+        logger.debug("Stored item vector (%s) for %s/%s", source, library_id, item_key)
+        return point_id
+
+    # ------------------------------------------------------------------
+    # Collection centroid computation
+    # ------------------------------------------------------------------
+
+    def compute_collection_centroid(
+        self,
+        library_id: str,
+        collection_id: str,
+        collection_name: str,
+        item_vectors: list[tuple[str, list[float], list[str]]],
+    ) -> Optional[str]:
+        """
+        Compute and persist a collection centroid vector.
+
+        Args:
+            library_id: Zotero library ID.
+            collection_id: Zotero collection ID.
+            collection_name: Human-readable collection name.
+            item_vectors: Full output of
+                ``vector_store.get_item_vectors_for_library(library_id)``.
+                Each element is ``(item_key, vector, collection_ids)``.
+
+        Returns:
+            Qdrant point UUID string, or ``None`` when no items belong to this
+            collection (centroid is undefined).
+        """
+        member_vectors = [
+            vec
+            for _item_key, vec, col_ids in item_vectors
+            if collection_id in col_ids
+        ]
+        if not member_vectors:
+            logger.debug(
+                "Collection %s/%s has no member item vectors — skipping centroid.",
+                library_id,
+                collection_id,
+            )
+            return None
+
+        centroid = _mean_vector(member_vectors)
+        point_id = self.vector_store.upsert_collection_vector(
+            library_id=library_id,
+            collection_id=collection_id,
+            collection_name=collection_name,
+            vector=centroid,
+            item_count=len(member_vectors),
+        )
+        logger.debug(
+            "Stored centroid for collection %s/%s (%d items)",
+            library_id,
+            collection_id,
+            len(member_vectors),
+        )
+        return point_id
+
+    # ------------------------------------------------------------------
+    # Full-library batch sync
+    # ------------------------------------------------------------------
+
+    async def sync_library(
+        self,
+        library_id: str,
+        collection_map: dict[str, list[str]],
+        collection_names: dict[str, str],
+        item_metadata: Optional[dict[str, dict]] = None,
+        progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    ) -> dict:
+        """
+        Full sync: compute item vectors for all items, then collection centroids.
+
+        Args:
+            library_id: Zotero library ID.
+            collection_map: ``{item_key: [collection_id, ...]}``.
+            collection_names: ``{collection_id: name}``.
+            item_metadata: Optional ``{item_key: {"title": ..., "abstract": ...}}``.
+                If provided, title and abstract are taken from here; otherwise
+                empty strings are used and the A1 fallback will apply.
+            progress_callback: Called after each item with
+                ``(completed_count, total_count, current_item_key)``.
+
+        Returns:
+            Stats dict with keys:
+            ``items_computed``, ``items_skipped``, ``collections_computed``,
+            ``collections_skipped``.
+        """
+        items_computed = 0
+        items_skipped = 0
+
+        item_keys = list(collection_map.keys())
+        total = len(item_keys)
+
+        for idx, item_key in enumerate(item_keys):
+            meta = (item_metadata or {}).get(item_key, {})
+            title = meta.get("title", "")
+            abstract = meta.get("abstract", "")
+            col_ids = collection_map.get(item_key, [])
+
+            result = await self.compute_item_vector(
+                library_id=library_id,
+                item_key=item_key,
+                title=title,
+                abstract=abstract,
+                collection_ids=col_ids,
+            )
+            if result is not None:
+                items_computed += 1
+            else:
+                items_skipped += 1
+
+            if progress_callback:
+                progress_callback(idx + 1, total, item_key)
+
+        # --- Collection centroids ---
+        # Reload all item vectors at once (single Qdrant scroll) for efficiency.
+        all_item_vectors = await asyncio.to_thread(
+            self.vector_store.get_item_vectors_for_library, library_id
+        )
+
+        collections_computed = 0
+        collections_skipped = 0
+
+        for collection_id, cname in collection_names.items():
+            result = self.compute_collection_centroid(
+                library_id=library_id,
+                collection_id=collection_id,
+                collection_name=cname,
+                item_vectors=all_item_vectors,
+            )
+            if result is not None:
+                collections_computed += 1
+            else:
+                collections_skipped += 1
+
+        stats = {
+            "items_computed": items_computed,
+            "items_skipped": items_skipped,
+            "collections_computed": collections_computed,
+            "collections_skipped": collections_skipped,
+        }
+        logger.info(
+            "sync_library %s complete: %s",
+            library_id,
+            stats,
+        )
+        return stats
+
+    # ------------------------------------------------------------------
+    # Incremental update
+    # ------------------------------------------------------------------
+
+    async def update_item(
+        self,
+        library_id: str,
+        item_key: str,
+        title: str,
+        abstract: str,
+        collection_ids: list[str],
+    ) -> bool:
+        """
+        Incremental update: recompute an item vector and refresh affected collection centroids.
+
+        After the item vector is (re)computed, all collections that contain this
+        item have their centroids recomputed using the full current set of item
+        vectors for the library.
+
+        Args:
+            library_id: Zotero library ID.
+            item_key: Zotero item key.
+            title: Current item title.
+            abstract: Current item abstract.
+            collection_ids: Collection IDs the item currently belongs to.
+
+        Returns:
+            ``True`` if the item vector was successfully computed and stored,
+            ``False`` if no data was available (item was skipped).
+        """
+        result = await self.compute_item_vector(
+            library_id=library_id,
+            item_key=item_key,
+            title=title,
+            abstract=abstract,
+            collection_ids=collection_ids,
+        )
+        if result is None:
+            return False
+
+        # Refresh centroids for all affected collections.
+        if collection_ids:
+            all_item_vectors = await asyncio.to_thread(
+                self.vector_store.get_item_vectors_for_library, library_id
+            )
+            for collection_id in collection_ids:
+                # Attempt to look up a stored name; fall back to the ID itself.
+                existing = self.vector_store.get_collection_vector(library_id, collection_id)
+                if existing is not None:
+                    _vec, payload = existing
+                    cname = payload.get("collection_name", collection_id)
+                else:
+                    cname = collection_id
+                self.compute_collection_centroid(
+                    library_id=library_id,
+                    collection_id=collection_id,
+                    collection_name=cname,
+                    item_vectors=all_item_vectors,
+                )
+
+        return True

--- a/backend/services/collection_vector_service.py
+++ b/backend/services/collection_vector_service.py
@@ -257,7 +257,8 @@ class CollectionVectorService:
         collections_skipped = 0
 
         for collection_id, cname in collection_names.items():
-            result = self.compute_collection_centroid(
+            result = await asyncio.to_thread(
+                self.compute_collection_centroid,
                 library_id=library_id,
                 collection_id=collection_id,
                 collection_name=cname,
@@ -328,13 +329,16 @@ class CollectionVectorService:
             )
             for collection_id in collection_ids:
                 # Attempt to look up a stored name; fall back to the ID itself.
-                existing = self.vector_store.get_collection_vector(library_id, collection_id)
+                existing = await asyncio.to_thread(
+                    self.vector_store.get_collection_vector, library_id, collection_id
+                )
                 if existing is not None:
                     _vec, payload = existing
                     cname = payload.get("collection_name", collection_id)
                 else:
                     cname = collection_id
-                self.compute_collection_centroid(
+                await asyncio.to_thread(
+                    self.compute_collection_centroid,
                     library_id=library_id,
                     collection_id=collection_id,
                     collection_name=cname,

--- a/backend/services/collection_vector_service.py
+++ b/backend/services/collection_vector_service.py
@@ -204,7 +204,7 @@ class CollectionVectorService:
         collection_names: dict[str, str],
         item_metadata: Optional[dict[str, dict]] = None,
         progress_callback: Optional[Callable[[int, int, str], None]] = None,
-    ) -> dict:
+    ) -> dict[str, int]:
         """
         Full sync: compute item vectors for all items, then collection centroids.
 

--- a/backend/services/collection_vector_service.py
+++ b/backend/services/collection_vector_service.py
@@ -103,6 +103,8 @@ class CollectionVectorService:
         vector: Optional[list[float]] = None
         source: Optional[str] = None
 
+        # DEBUG
+        logger.debug("compute_item_vector: %s/%s embed_text_len=%d has_full_abstract=%s", library_id, item_key, len(embed_text), has_full_abstract)
         if embed_text:
             vector = await self.embedding_service.embed_text(embed_text)
             # Treat an all-zero or empty result as unusable
@@ -117,8 +119,8 @@ class CollectionVectorService:
                 self.vector_store.get_chunk_vectors_for_item, library_id, item_key
             )
             if not chunk_vectors:
-                logger.debug(
-                    "No text or chunks available for item %s/%s — skipping.",
+                logger.debug(  # DEBUG
+                    "compute_item_vector: no text or chunks for %s/%s - skipping",
                     library_id,
                     item_key,
                 )

--- a/backend/tests/test_api_collections.py
+++ b/backend/tests/test_api_collections.py
@@ -127,7 +127,7 @@ class TestCollectionsAPI(unittest.TestCase):
         self.assertEqual(data[0]["library_id"], "lib1")
         self.assertEqual(data[1]["collection_id"], "col2")
 
-        mock_vs.search_collection_vectors.assert_called_once_with(item_vec, "lib1", limit=5)
+        mock_vs.search_collection_vectors.assert_called_once_with(item_vec, limit=5)
 
     def test_suggest_clamps_limit_to_20(self):
         """limit parameter above 20 is rejected with 422 (FastAPI Query validation)."""

--- a/backend/tests/test_api_collections.py
+++ b/backend/tests/test_api_collections.py
@@ -7,9 +7,8 @@ Covers:
 - GET  /api/collections/suggest
 """
 
-import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -131,7 +130,7 @@ class TestCollectionsAPI(unittest.TestCase):
         mock_vs.search_collection_vectors.assert_called_once_with(item_vec, "lib1", limit=5)
 
     def test_suggest_clamps_limit_to_20(self):
-        """limit parameter is clamped to a maximum of 20."""
+        """limit parameter above 20 is rejected with 422 (FastAPI Query validation)."""
         mock_vs = MagicMock()
         mock_vs.get_item_vector.return_value = ([0.0] * 8, {})
         mock_vs.search_collection_vectors.return_value = []
@@ -142,10 +141,7 @@ class TestCollectionsAPI(unittest.TestCase):
             params={"library_id": "lib1", "item_key": "KEY", "limit": "100"},
         )
 
-        self.assertEqual(response.status_code, 200)
-        # Verify the actual limit passed to the store was clamped
-        _, call_kwargs = mock_vs.search_collection_vectors.call_args
-        self.assertEqual(call_kwargs.get("limit", None) or mock_vs.search_collection_vectors.call_args[0][2], 20)
+        self.assertEqual(response.status_code, 422)
 
     def test_suggest_503_when_no_store(self):
         """Returns 503 when vector store is unavailable."""

--- a/backend/tests/test_api_collections.py
+++ b/backend/tests/test_api_collections.py
@@ -1,0 +1,273 @@
+"""
+Tests for collections API endpoints.
+
+Covers:
+- GET  /api/collections/vectors/status
+- POST /api/collections/vectors/sync
+- GET  /api/collections/suggest
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.dependencies import get_vector_store
+
+
+class TestCollectionsAPI(unittest.TestCase):
+    """Test suite for the /api/collections/* endpoints."""
+
+    def setUp(self):
+        from backend.main import app
+        self.app = app
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+
+    def _override_vs(self, mock_vs):
+        """Register mock VectorStore as a FastAPI dependency override."""
+        self.app.dependency_overrides[get_vector_store] = lambda: mock_vs
+
+    # ------------------------------------------------------------------
+    # GET /api/collections/vectors/status
+    # ------------------------------------------------------------------
+
+    def test_get_collection_vectors_status_returns_counts(self):
+        """Status endpoint returns correct item and collection vector counts."""
+        mock_vs = MagicMock()
+        mock_vs.count_item_vectors.return_value = 42
+        mock_vs.count_collection_vectors.return_value = 7
+        self._override_vs(mock_vs)
+
+        response = self.client.get(
+            "/api/collections/vectors/status",
+            params={"library_id": "lib1"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["library_id"], "lib1")
+        self.assertEqual(data["item_vectors_count"], 42)
+        self.assertEqual(data["collection_vectors_count"], 7)
+        self.assertTrue(data["computed"])
+        mock_vs.count_item_vectors.assert_called_once_with("lib1")
+        mock_vs.count_collection_vectors.assert_called_once_with("lib1")
+
+    def test_get_collection_vectors_status_computed_false_when_zero(self):
+        """computed flag is False when collection_vectors_count is 0."""
+        mock_vs = MagicMock()
+        mock_vs.count_item_vectors.return_value = 10
+        mock_vs.count_collection_vectors.return_value = 0
+        self._override_vs(mock_vs)
+
+        response = self.client.get(
+            "/api/collections/vectors/status",
+            params={"library_id": "lib2"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["collection_vectors_count"], 0)
+        self.assertFalse(data["computed"])
+
+    def test_get_collection_vectors_status_503_when_no_store(self):
+        """Returns 503 when vector store is unavailable."""
+        self._override_vs(None)
+
+        response = self.client.get(
+            "/api/collections/vectors/status",
+            params={"library_id": "lib1"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+
+    # ------------------------------------------------------------------
+    # GET /api/collections/suggest
+    # ------------------------------------------------------------------
+
+    def test_suggest_returns_empty_list_when_no_item_vector(self):
+        """Returns [] (not 404) when no pre-computed item vector exists."""
+        mock_vs = MagicMock()
+        mock_vs.get_item_vector.return_value = None
+        self._override_vs(mock_vs)
+
+        response = self.client.get(
+            "/api/collections/suggest",
+            params={"library_id": "lib1", "item_key": "MISSING"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+        mock_vs.get_item_vector.assert_called_once_with("lib1", "MISSING")
+
+    def test_suggest_returns_suggestions_when_vectors_exist(self):
+        """Returns suggestions sorted by score when both item and collection vectors exist."""
+        mock_vs = MagicMock()
+        item_vec = [0.1] * 8
+        mock_vs.get_item_vector.return_value = (item_vec, {"item_key": "ITEMKEY"})
+        mock_vs.search_collection_vectors.return_value = [
+            ("col1", 0.95, {"collection_name": "Physics", "collection_id": "col1"}),
+            ("col2", 0.80, {"collection_name": "Chemistry", "collection_id": "col2"}),
+        ]
+        self._override_vs(mock_vs)
+
+        response = self.client.get(
+            "/api/collections/suggest",
+            params={"library_id": "lib1", "item_key": "ITEMKEY", "limit": "5"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["collection_id"], "col1")
+        self.assertEqual(data[0]["collection_name"], "Physics")
+        self.assertAlmostEqual(data[0]["score"], 0.95)
+        self.assertEqual(data[0]["library_id"], "lib1")
+        self.assertEqual(data[1]["collection_id"], "col2")
+
+        mock_vs.search_collection_vectors.assert_called_once_with(item_vec, "lib1", limit=5)
+
+    def test_suggest_clamps_limit_to_20(self):
+        """limit parameter is clamped to a maximum of 20."""
+        mock_vs = MagicMock()
+        mock_vs.get_item_vector.return_value = ([0.0] * 8, {})
+        mock_vs.search_collection_vectors.return_value = []
+        self._override_vs(mock_vs)
+
+        response = self.client.get(
+            "/api/collections/suggest",
+            params={"library_id": "lib1", "item_key": "KEY", "limit": "100"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        # Verify the actual limit passed to the store was clamped
+        _, call_kwargs = mock_vs.search_collection_vectors.call_args
+        self.assertEqual(call_kwargs.get("limit", None) or mock_vs.search_collection_vectors.call_args[0][2], 20)
+
+    def test_suggest_503_when_no_store(self):
+        """Returns 503 when vector store is unavailable."""
+        self._override_vs(None)
+
+        response = self.client.get(
+            "/api/collections/suggest",
+            params={"library_id": "lib1", "item_key": "KEY"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+
+    def test_suggest_missing_collection_name_defaults_to_empty_string(self):
+        """Collection name defaults to '' when absent from payload."""
+        mock_vs = MagicMock()
+        mock_vs.get_item_vector.return_value = ([0.1] * 8, {})
+        # payload without collection_name
+        mock_vs.search_collection_vectors.return_value = [
+            ("col9", 0.70, {"collection_id": "col9"}),
+        ]
+        self._override_vs(mock_vs)
+
+        response = self.client.get(
+            "/api/collections/suggest",
+            params={"library_id": "lib1", "item_key": "KEY"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]["collection_name"], "")
+
+    # ------------------------------------------------------------------
+    # POST /api/collections/vectors/sync
+    # ------------------------------------------------------------------
+
+    def test_sync_processes_collection_map_and_returns_stats(self):
+        """Sync endpoint delegates to CollectionVectorService and returns stats dict."""
+        mock_vs = MagicMock()
+        self._override_vs(mock_vs)
+
+        expected_stats = {
+            "items_computed": 2,
+            "items_skipped": 0,
+            "collections_computed": 1,
+            "collections_skipped": 0,
+        }
+
+        with patch(
+            "backend.api.collections.CollectionVectorService"
+        ) as MockSvc, patch(
+            "backend.api.collections.make_embedding_service"
+        ) as mock_make_emb:
+            mock_svc_instance = MagicMock()
+            mock_svc_instance.sync_library = AsyncMock(return_value=expected_stats)
+            MockSvc.return_value = mock_svc_instance
+            mock_make_emb.return_value = MagicMock()
+
+            response = self.client.post(
+                "/api/collections/vectors/sync",
+                json={
+                    "library_id": "lib1",
+                    "collection_map": {
+                        "ITEM1": ["col1"],
+                        "ITEM2": ["col1"],
+                    },
+                    "collection_names": {"col1": "Physics"},
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["items_computed"], 2)
+        self.assertEqual(data["collections_computed"], 1)
+
+        # Verify service was constructed and called correctly
+        MockSvc.assert_called_once_with(mock_vs, mock_make_emb.return_value)
+        mock_svc_instance.sync_library.assert_awaited_once_with(
+            library_id="lib1",
+            collection_map={"ITEM1": ["col1"], "ITEM2": ["col1"]},
+            collection_names={"col1": "Physics"},
+        )
+
+    def test_sync_503_when_no_store(self):
+        """Sync returns 503 when vector store is unavailable."""
+        self._override_vs(None)
+
+        response = self.client.post(
+            "/api/collections/vectors/sync",
+            json={
+                "library_id": "lib1",
+                "collection_map": {},
+                "collection_names": {},
+            },
+        )
+
+        self.assertEqual(response.status_code, 503)
+
+    def test_sync_uses_default_empty_collection_names(self):
+        """Sync request works without collection_names field (defaults to {})."""
+        mock_vs = MagicMock()
+        self._override_vs(mock_vs)
+
+        stats = {"items_computed": 0, "items_skipped": 0, "collections_computed": 0, "collections_skipped": 0}
+
+        with patch("backend.api.collections.CollectionVectorService") as MockSvc, \
+             patch("backend.api.collections.make_embedding_service"):
+            mock_svc_instance = MagicMock()
+            mock_svc_instance.sync_library = AsyncMock(return_value=stats)
+            MockSvc.return_value = mock_svc_instance
+
+            response = self.client.post(
+                "/api/collections/vectors/sync",
+                json={"library_id": "lib1", "collection_map": {}},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_svc_instance.sync_library.assert_awaited_once_with(
+            library_id="lib1",
+            collection_map={},
+            collection_names={},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_collection_vector_service.py
+++ b/backend/tests/test_collection_vector_service.py
@@ -123,48 +123,6 @@ class ZeroEmbeddingService(EmbeddingService):
 
 
 # ---------------------------------------------------------------------------
-# Base test case with shared setup / teardown
-# ---------------------------------------------------------------------------
-
-class _BaseServiceTest(unittest.IsolatedAsyncioTestCase):
-    """Async test base: creates a temp Qdrant store and a service instance."""
-
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-        self.store = _make_store(self.temp_dir)
-        self.embed_svc = DeterministicEmbeddingService(dim=DIM)
-        self.svc = CollectionVectorService(
-            vector_store=self.store,
-            embedding_service=self.embed_svc,
-            min_abstract_chars=50,
-        )
-
-    def tearDown(self):
-        self.store.close()
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    def _add_chunk(self, item_key: str, chunk_index: int, vector: list[float]):
-        """Helper: insert a document chunk with a known vector."""
-        chunk = DocumentChunk(
-            text=f"Chunk text {chunk_index}",
-            metadata=ChunkMetadata(
-                chunk_id=f"{LIB}:{item_key}:{chunk_index}",
-                document_metadata=DocumentMetadata(
-                    library_id=LIB,
-                    item_key=item_key,
-                    title="Test Title",
-                ),
-                page_number=1,
-                text_preview="Chunk text",
-                chunk_index=chunk_index,
-                content_hash=f"hash-{item_key}-{chunk_index}",
-            ),
-            embedding=vector,
-        )
-        self.store.add_chunk(chunk)
-
-
-# ---------------------------------------------------------------------------
 # compute_item_vector — A2 path (title + abstract)
 # ---------------------------------------------------------------------------
 
@@ -234,6 +192,20 @@ class TestComputeItemVectorA2(unittest.IsolatedAsyncioTestCase):
                 collection_ids=[],
             )
         self.assertEqual(self.store.count_item_vectors(LIB), 1)
+
+    async def test_short_abstract_records_title_source(self):
+        """When the abstract is too short but the title is non-empty, source must be 'title'."""
+        await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="TITLE_ONLY",
+            title="A paper with only a title",
+            abstract="short",  # < 50 chars → title-only embedding
+            collection_ids=[],
+        )
+        result = self.store.get_item_vector(LIB, "TITLE_ONLY")
+        self.assertIsNotNone(result)
+        _vec, payload = result
+        self.assertEqual(payload["source"], "title")
 
 
 # ---------------------------------------------------------------------------
@@ -714,6 +686,53 @@ class TestUpdateItem(unittest.IsolatedAsyncioTestCase):
         # The centroid must have been recomputed; if ITEM2's vector changed the mean differs
         # (We can't guarantee they differ because the mock is deterministic, but count of stored must be >= 1)
         self.assertIsNotNone(after_centroid)
+
+    async def test_old_collection_centroid_refreshed_when_item_moves(self):
+        """When an item moves from colOld to colNew, colOld's centroid must also be recomputed."""
+        # Seed item in colOld
+        await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="MOVER",
+            title="Mover paper",
+            abstract="A" * 60,
+            collection_ids=["colOld"],
+        )
+        # Compute initial centroid for colOld
+        all_vecs = self.store.get_item_vectors_for_library(LIB)
+        self.svc.compute_collection_centroid(
+            library_id=LIB,
+            collection_id="colOld",
+            collection_name="Old Collection",
+            item_vectors=all_vecs,
+        )
+        # Seed a second item in colNew so its centroid can also be stored
+        await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="STATIC",
+            title="Static paper",
+            abstract="B" * 60,
+            collection_ids=["colNew"],
+        )
+        all_vecs = self.store.get_item_vectors_for_library(LIB)
+        self.svc.compute_collection_centroid(
+            library_id=LIB,
+            collection_id="colNew",
+            collection_name="New Collection",
+            item_vectors=all_vecs,
+        )
+
+        # Move MOVER to colNew — update_item must refresh both colOld and colNew
+        await self.svc.update_item(
+            library_id=LIB,
+            item_key="MOVER",
+            title="Mover paper",
+            abstract="A" * 60,
+            collection_ids=["colNew"],
+        )
+
+        # Both centroids must still exist (colOld recomputed to reflect the item leaving)
+        self.assertIsNotNone(self.store.get_collection_vector(LIB, "colOld"))
+        self.assertIsNotNone(self.store.get_collection_vector(LIB, "colNew"))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_collection_vector_service.py
+++ b/backend/tests/test_collection_vector_service.py
@@ -1,0 +1,720 @@
+"""
+Unit tests for CollectionVectorService.
+
+Uses a real in-memory VectorStore (local Qdrant) and a deterministic mock
+EmbeddingService so tests are fast, reproducible, and require no external services.
+"""
+
+import asyncio
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Callable, Optional
+
+from qdrant_client.models import Distance
+
+from backend.db.vector_store import VectorStore
+from backend.models.document import (
+    ChunkMetadata,
+    DocumentChunk,
+    DocumentMetadata,
+)
+from backend.services.collection_vector_service import CollectionVectorService
+from backend.services.embeddings import EmbeddingService
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DIM = 8          # small dimension — fast tests, deterministic arithmetic
+LIB = "lib_test"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _unit_vec(index: int, dim: int = DIM) -> list[float]:
+    """Return a unit vector with 1.0 at ``index % dim`` and 0.0 elsewhere."""
+    v = [0.0] * dim
+    v[index % dim] = 1.0
+    return v
+
+
+def _make_store(tmp_dir: str) -> VectorStore:
+    return VectorStore(
+        storage_path=Path(tmp_dir) / "qdrant",
+        embedding_dim=DIM,
+        embedding_model_name="test-model",
+        distance=Distance.COSINE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic mock embedding service
+# ---------------------------------------------------------------------------
+
+class DeterministicEmbeddingService(EmbeddingService):
+    """
+    Returns a fixed vector based on the hash of the input text.
+
+    The vector is never all-zeros, so the service always produces a usable
+    A2 result when a non-empty text is given.
+    """
+
+    def __init__(self, dim: int = DIM):
+        self._dim = dim
+
+    async def embed_text(self, text: str) -> list[float]:
+        if not text.strip():
+            return [0.0] * self._dim
+        # Produce a stable non-zero vector from the text content
+        seed = sum(ord(c) for c in text)
+        v = [(((seed * (i + 1)) % 97) / 97.0) for i in range(self._dim)]
+        # Ensure at least one non-zero component
+        v[0] = max(v[0], 0.01)
+        return v
+
+    async def embed_batch(
+        self,
+        texts: list[str],
+        on_batch: Optional[Callable[[int, int], None]] = None,
+    ) -> list[list[float]]:
+        results = [await self.embed_text(t) for t in texts]
+        if on_batch and texts:
+            on_batch(len(texts), len(texts))
+        return results
+
+    def get_embedding_dim(self) -> int:
+        return self._dim
+
+    def get_model_name(self) -> str:
+        return "deterministic-mock"
+
+    async def get_rate_limit_info(self) -> dict[str, str] | None:
+        return None
+
+
+class ZeroEmbeddingService(EmbeddingService):
+    """Always returns an all-zero vector (simulates missing/unavailable embedding)."""
+
+    def __init__(self, dim: int = DIM):
+        self._dim = dim
+
+    async def embed_text(self, text: str) -> list[float]:
+        return [0.0] * self._dim
+
+    async def embed_batch(
+        self,
+        texts: list[str],
+        on_batch: Optional[Callable[[int, int], None]] = None,
+    ) -> list[list[float]]:
+        return [[0.0] * self._dim for _ in texts]
+
+    def get_embedding_dim(self) -> int:
+        return self._dim
+
+    def get_model_name(self) -> str:
+        return "zero-mock"
+
+    async def get_rate_limit_info(self) -> dict[str, str] | None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Base test case with shared setup / teardown
+# ---------------------------------------------------------------------------
+
+class _BaseServiceTest(unittest.IsolatedAsyncioTestCase):
+    """Async test base: creates a temp Qdrant store and a service instance."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+        self.embed_svc = DeterministicEmbeddingService(dim=DIM)
+        self.svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=self.embed_svc,
+            min_abstract_chars=50,
+        )
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _add_chunk(self, item_key: str, chunk_index: int, vector: list[float]):
+        """Helper: insert a document chunk with a known vector."""
+        chunk = DocumentChunk(
+            text=f"Chunk text {chunk_index}",
+            metadata=ChunkMetadata(
+                chunk_id=f"{LIB}:{item_key}:{chunk_index}",
+                document_metadata=DocumentMetadata(
+                    library_id=LIB,
+                    item_key=item_key,
+                    title="Test Title",
+                ),
+                page_number=1,
+                text_preview="Chunk text",
+                chunk_index=chunk_index,
+                content_hash=f"hash-{item_key}-{chunk_index}",
+            ),
+            embedding=vector,
+        )
+        self.store.add_chunk(chunk)
+
+
+# ---------------------------------------------------------------------------
+# compute_item_vector — A2 path (title + abstract)
+# ---------------------------------------------------------------------------
+
+class TestComputeItemVectorA2(unittest.IsolatedAsyncioTestCase):
+    """compute_item_vector with a valid abstract uses the A2 (embedding) path."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+        self.embed_svc = DeterministicEmbeddingService(dim=DIM)
+        self.svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=self.embed_svc,
+            min_abstract_chars=50,
+        )
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    async def test_returns_point_id(self):
+        point_id = await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="ITEM1",
+            title="A wonderful paper",
+            abstract="This paper describes an important discovery " * 3,
+            collection_ids=["col1"],
+        )
+        self.assertIsNotNone(point_id)
+        self.assertIsInstance(point_id, str)
+
+    async def test_vector_stored_with_abstract_source(self):
+        await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="ITEM1",
+            title="A wonderful paper",
+            abstract="This paper describes an important discovery in science.",
+            collection_ids=["col1"],
+        )
+        result = self.store.get_item_vector(LIB, "ITEM1")
+        self.assertIsNotNone(result)
+        _vec, payload = result
+        self.assertEqual(payload["source"], "abstract")
+        self.assertEqual(payload["item_key"], "ITEM1")
+        self.assertEqual(payload["collection_ids"], ["col1"])
+
+    async def test_stored_vector_is_non_zero(self):
+        await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="ITEM2",
+            title="Another paper",
+            abstract="The abstract contains enough characters to pass the minimum threshold here.",
+            collection_ids=[],
+        )
+        result = self.store.get_item_vector(LIB, "ITEM2")
+        vec, _payload = result
+        self.assertTrue(any(v != 0.0 for v in vec))
+
+    async def test_idempotent_upsert(self):
+        """Calling compute_item_vector twice should not create duplicates."""
+        for _ in range(2):
+            await self.svc.compute_item_vector(
+                library_id=LIB,
+                item_key="ITEM1",
+                title="Paper",
+                abstract="Abstract that is definitely longer than fifty characters total here.",
+                collection_ids=[],
+            )
+        self.assertEqual(self.store.count_item_vectors(LIB), 1)
+
+
+# ---------------------------------------------------------------------------
+# compute_item_vector — A1 fallback (short/empty abstract → chunk mean)
+# ---------------------------------------------------------------------------
+
+class TestComputeItemVectorA1Fallback(unittest.IsolatedAsyncioTestCase):
+    """Short abstract triggers A1 fallback; result must be the mean of chunk vectors."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+        # Use zero-embedding service so A2 always fails → forces A1 fallback
+        self.embed_svc = ZeroEmbeddingService(dim=DIM)
+        self.svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=self.embed_svc,
+            min_abstract_chars=50,
+        )
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _add_chunk(self, item_key: str, chunk_index: int, vector: list[float]):
+        chunk = DocumentChunk(
+            text=f"Chunk text {chunk_index}",
+            metadata=ChunkMetadata(
+                chunk_id=f"{LIB}:{item_key}:{chunk_index}",
+                document_metadata=DocumentMetadata(
+                    library_id=LIB,
+                    item_key=item_key,
+                    title="Test",
+                ),
+                page_number=1,
+                text_preview="Chunk",
+                chunk_index=chunk_index,
+                content_hash=f"hash-{item_key}-{chunk_index}",
+            ),
+            embedding=vector,
+        )
+        self.store.add_chunk(chunk)
+
+    async def test_short_abstract_uses_chunks(self):
+        """When abstract is too short, the service falls back to chunk mean."""
+        vec0 = _unit_vec(0)  # [1,0,0,0,0,0,0,0]
+        vec1 = _unit_vec(2)  # [0,0,1,0,0,0,0,0]
+        self._add_chunk("ITEM1", 0, vec0)
+        self._add_chunk("ITEM1", 1, vec1)
+
+        point_id = await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="ITEM1",
+            title="Title",
+            abstract="short",  # < 50 chars → A2 text is only the title
+            collection_ids=[],
+        )
+        self.assertIsNotNone(point_id)
+
+        result = self.store.get_item_vector(LIB, "ITEM1")
+        _vec, payload = result
+        self.assertEqual(payload["source"], "chunks")
+
+    async def test_chunk_mean_vector_is_correct(self):
+        """The stored vector direction must match the arithmetic mean of chunk vectors.
+
+        Qdrant normalises COSINE vectors on retrieval, so we compare the
+        normalised form of the expected mean rather than the raw values.
+        """
+        import math
+
+        vec0 = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        vec1 = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        self._add_chunk("ITEM_MEAN", 0, vec0)
+        self._add_chunk("ITEM_MEAN", 1, vec1)
+
+        await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="ITEM_MEAN",
+            title="",
+            abstract="",  # empty → A2 text is empty → A1 fallback
+            collection_ids=[],
+        )
+
+        result = self.store.get_item_vector(LIB, "ITEM_MEAN")
+        stored_vec, _payload = result
+
+        # Compute expected: mean of vec0 and vec1, then L2-normalise (as Qdrant would)
+        raw_mean = [0.5, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0]
+        norm = math.sqrt(sum(x * x for x in raw_mean))
+        expected_normalised = [x / norm for x in raw_mean]
+
+        for a, b in zip(stored_vec, expected_normalised):
+            self.assertAlmostEqual(a, b, places=5)
+
+
+# ---------------------------------------------------------------------------
+# compute_item_vector — no abstract and no chunks → returns None
+# ---------------------------------------------------------------------------
+
+class TestComputeItemVectorNoData(unittest.IsolatedAsyncioTestCase):
+    """When there is neither usable text nor chunks, the method must return None."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+        # Zero embedder so that even a non-empty title produces nothing useful
+        self.embed_svc = ZeroEmbeddingService(dim=DIM)
+        self.svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=self.embed_svc,
+            min_abstract_chars=50,
+        )
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    async def test_returns_none_when_no_data(self):
+        result = await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key="GHOST",
+            title="",
+            abstract="",
+            collection_ids=[],
+        )
+        self.assertIsNone(result)
+        self.assertIsNone(self.store.get_item_vector(LIB, "GHOST"))
+
+
+# ---------------------------------------------------------------------------
+# compute_collection_centroid
+# ---------------------------------------------------------------------------
+
+class TestComputeCollectionCentroid(unittest.IsolatedAsyncioTestCase):
+    """Centroid computation tests."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+        self.svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=DeterministicEmbeddingService(dim=DIM),
+            min_abstract_chars=50,
+        )
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_item_vectors(
+        self, entries: list[tuple[str, list[float], list[str]]]
+    ) -> list[tuple[str, list[float], list[str]]]:
+        """Convenience: return a pre-built item_vectors list."""
+        return entries
+
+    async def test_centroid_with_two_items(self):
+        """Centroid direction must match the arithmetic mean of member vectors.
+
+        Qdrant normalises COSINE vectors on retrieval, so we compare the
+        normalised form of the expected mean.
+        """
+        import math
+
+        vec0 = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        vec1 = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        item_vectors = [
+            ("ITEM0", vec0, ["colA"]),
+            ("ITEM1", vec1, ["colA"]),
+            ("ITEM2", _unit_vec(4), ["colB"]),  # Different collection — must be excluded
+        ]
+
+        point_id = self.svc.compute_collection_centroid(
+            library_id=LIB,
+            collection_id="colA",
+            collection_name="Collection A",
+            item_vectors=item_vectors,
+        )
+        self.assertIsNotNone(point_id)
+
+        result = self.store.get_collection_vector(LIB, "colA")
+        stored_vec, payload = result
+
+        # Mean of vec0 and vec1, then L2-normalise
+        raw_mean = [0.5, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0]
+        norm = math.sqrt(sum(x * x for x in raw_mean))
+        expected_normalised = [x / norm for x in raw_mean]
+
+        for a, b in zip(stored_vec, expected_normalised):
+            self.assertAlmostEqual(a, b, places=5)
+        self.assertEqual(payload["item_count"], 2)
+        self.assertEqual(payload["collection_name"], "Collection A")
+
+    async def test_centroid_with_zero_items_returns_none(self):
+        """A collection with no members should yield None (no point stored)."""
+        item_vectors = [
+            ("ITEM0", _unit_vec(0), ["other_col"]),
+        ]
+        result = self.svc.compute_collection_centroid(
+            library_id=LIB,
+            collection_id="empty_col",
+            collection_name="Empty",
+            item_vectors=item_vectors,
+        )
+        self.assertIsNone(result)
+        self.assertIsNone(self.store.get_collection_vector(LIB, "empty_col"))
+
+    async def test_centroid_stores_item_count(self):
+        item_vectors = [
+            (f"ITEM{i}", _unit_vec(i), ["colX"]) for i in range(5)
+        ]
+        self.svc.compute_collection_centroid(
+            library_id=LIB,
+            collection_id="colX",
+            collection_name="X",
+            item_vectors=item_vectors,
+        )
+        _vec, payload = self.store.get_collection_vector(LIB, "colX")
+        self.assertEqual(payload["item_count"], 5)
+
+
+# ---------------------------------------------------------------------------
+# sync_library
+# ---------------------------------------------------------------------------
+
+class TestSyncLibrary(unittest.IsolatedAsyncioTestCase):
+    """sync_library processes all items and all collections, returning correct stats."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+        self.embed_svc = DeterministicEmbeddingService(dim=DIM)
+        self.svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=self.embed_svc,
+            min_abstract_chars=50,
+        )
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    async def test_all_items_computed_when_metadata_provided(self):
+        """All items with sufficient metadata must be computed (not skipped)."""
+        collection_map = {
+            "ITEM1": ["colA", "colB"],
+            "ITEM2": ["colA"],
+            "ITEM3": ["colC"],
+        }
+        collection_names = {"colA": "A", "colB": "B", "colC": "C"}
+        item_metadata = {
+            "ITEM1": {
+                "title": "Paper one",
+                "abstract": "This abstract is definitely longer than fifty characters to pass.",
+            },
+            "ITEM2": {
+                "title": "Paper two",
+                "abstract": "Another abstract that is also long enough to qualify for embedding.",
+            },
+            "ITEM3": {
+                "title": "Paper three",
+                "abstract": "Yet another abstract with a sufficient number of characters here.",
+            },
+        }
+
+        stats = await self.svc.sync_library(
+            library_id=LIB,
+            collection_map=collection_map,
+            collection_names=collection_names,
+            item_metadata=item_metadata,
+        )
+
+        self.assertEqual(stats["items_computed"], 3)
+        self.assertEqual(stats["items_skipped"], 0)
+        self.assertEqual(stats["collections_computed"], 3)
+        self.assertEqual(stats["collections_skipped"], 0)
+
+    async def test_item_skipped_when_no_data(self):
+        """Items with no text and no chunks must appear in items_skipped."""
+        # Force zero embedder so A2 always fails
+        svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=ZeroEmbeddingService(dim=DIM),
+            min_abstract_chars=50,
+        )
+        collection_map = {"GHOST": ["colA"]}
+        collection_names = {"colA": "A"}
+
+        stats = await svc.sync_library(
+            library_id=LIB,
+            collection_map=collection_map,
+            collection_names=collection_names,
+        )
+
+        self.assertEqual(stats["items_computed"], 0)
+        self.assertEqual(stats["items_skipped"], 1)
+        # colA has no member vectors → must also be skipped
+        self.assertEqual(stats["collections_skipped"], 1)
+
+    async def test_progress_callback_called(self):
+        """progress_callback must be called once per item."""
+        calls = []
+
+        def _cb(completed: int, total: int, item_key: str):
+            calls.append((completed, total, item_key))
+
+        collection_map = {
+            "ITEM1": ["colA"],
+            "ITEM2": ["colA"],
+        }
+        item_metadata = {
+            "ITEM1": {"title": "T1", "abstract": "A" * 60},
+            "ITEM2": {"title": "T2", "abstract": "B" * 60},
+        }
+
+        await self.svc.sync_library(
+            library_id=LIB,
+            collection_map=collection_map,
+            collection_names={"colA": "A"},
+            item_metadata=item_metadata,
+            progress_callback=_cb,
+        )
+
+        self.assertEqual(len(calls), 2)
+        # Last call must report total == total
+        self.assertEqual(calls[-1][0], 2)
+        self.assertEqual(calls[-1][1], 2)
+
+    async def test_collection_centroid_not_computed_for_empty_collection(self):
+        """Collections with no items in collection_map are skipped."""
+        collection_map = {"ITEM1": ["colA"]}  # colB has no items
+        collection_names = {"colA": "A", "colB": "B (empty)"}
+        item_metadata = {
+            "ITEM1": {"title": "T1", "abstract": "A" * 60},
+        }
+
+        stats = await self.svc.sync_library(
+            library_id=LIB,
+            collection_map=collection_map,
+            collection_names=collection_names,
+            item_metadata=item_metadata,
+        )
+
+        self.assertEqual(stats["collections_computed"], 1)
+        self.assertEqual(stats["collections_skipped"], 1)
+        self.assertIsNone(self.store.get_collection_vector(LIB, "colB"))
+
+
+# ---------------------------------------------------------------------------
+# update_item
+# ---------------------------------------------------------------------------
+
+class TestUpdateItem(unittest.IsolatedAsyncioTestCase):
+    """update_item updates the item vector and recomputes affected collection centroids."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+        self.embed_svc = DeterministicEmbeddingService(dim=DIM)
+        self.svc = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=self.embed_svc,
+            min_abstract_chars=50,
+        )
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    async def _seed_item(self, item_key: str, col_ids: list[str]):
+        """Store an item vector with a known title/abstract."""
+        await self.svc.compute_item_vector(
+            library_id=LIB,
+            item_key=item_key,
+            title=f"Title of {item_key}",
+            abstract="A" * 60,
+            collection_ids=col_ids,
+        )
+
+    async def test_update_returns_true_when_successful(self):
+        result = await self.svc.update_item(
+            library_id=LIB,
+            item_key="ITEM1",
+            title="Updated title",
+            abstract="B" * 60,
+            collection_ids=["colA"],
+        )
+        self.assertTrue(result)
+
+    async def test_update_returns_false_when_no_data(self):
+        svc_zero = CollectionVectorService(
+            vector_store=self.store,
+            embedding_service=ZeroEmbeddingService(dim=DIM),
+            min_abstract_chars=50,
+        )
+        result = await svc_zero.update_item(
+            library_id=LIB,
+            item_key="GHOST",
+            title="",
+            abstract="",
+            collection_ids=[],
+        )
+        self.assertFalse(result)
+
+    async def test_item_vector_is_updated(self):
+        """Vector stored after update_item must differ from the original."""
+        # First pass
+        await self._seed_item("ITEM1", ["colA"])
+        before_result = self.store.get_item_vector(LIB, "ITEM1")
+        before_vec = before_result[0]
+
+        # Update with different text
+        await self.svc.update_item(
+            library_id=LIB,
+            item_key="ITEM1",
+            title="Completely different title now",
+            abstract="Z" * 70,
+            collection_ids=["colA"],
+        )
+        after_result = self.store.get_item_vector(LIB, "ITEM1")
+        after_vec = after_result[0]
+
+        # The vector should differ because the embedding input changed
+        self.assertNotEqual(before_vec, after_vec)
+
+    async def test_collection_centroid_is_recomputed(self):
+        """After update_item the affected collection centroid must be stored."""
+        await self._seed_item("ITEM1", ["colA"])
+
+        # Pre-store a centroid with a known name so update_item can look it up
+        all_vecs = self.store.get_item_vectors_for_library(LIB)
+        self.svc.compute_collection_centroid(
+            library_id=LIB,
+            collection_id="colA",
+            collection_name="Collection A",
+            item_vectors=all_vecs,
+        )
+
+        # Update the item and verify centroid still exists (was recomputed)
+        await self.svc.update_item(
+            library_id=LIB,
+            item_key="ITEM1",
+            title="Updated",
+            abstract="C" * 60,
+            collection_ids=["colA"],
+        )
+
+        result = self.store.get_collection_vector(LIB, "colA")
+        self.assertIsNotNone(result)
+        _vec, payload = result
+        self.assertEqual(payload["collection_name"], "Collection A")
+
+    async def test_multiple_items_collection_centroid_updated(self):
+        """With two items in the same collection, centroid reflects both vectors."""
+        await self._seed_item("ITEM1", ["colA"])
+        await self._seed_item("ITEM2", ["colA"])
+
+        # Compute initial centroid
+        all_vecs = self.store.get_item_vectors_for_library(LIB)
+        self.svc.compute_collection_centroid(
+            library_id=LIB,
+            collection_id="colA",
+            collection_name="A",
+            item_vectors=all_vecs,
+        )
+        before_centroid = self.store.get_collection_vector(LIB, "colA")[0]
+
+        # Update one of them and verify the centroid changes
+        await self.svc.update_item(
+            library_id=LIB,
+            item_key="ITEM2",
+            title="Very different paper about quantum mechanics now",
+            abstract="D" * 80,
+            collection_ids=["colA"],
+        )
+
+        after_centroid = self.store.get_collection_vector(LIB, "colA")[0]
+        # The centroid must have been recomputed; if ITEM2's vector changed the mean differs
+        # (We can't guarantee they differ because the mock is deterministic, but count of stored must be >= 1)
+        self.assertIsNotNone(after_centroid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_collection_vector_store.py
+++ b/backend/tests/test_collection_vector_store.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for item_vectors and collection_vectors storage in VectorStore.
+"""
+
+import unittest
+import tempfile
+import shutil
+from pathlib import Path
+
+from qdrant_client.models import Distance
+
+from backend.db.vector_store import VectorStore
+from backend.models.document import (
+    DocumentChunk,
+    ChunkMetadata,
+    DocumentMetadata,
+)
+
+
+# Shared helpers
+DIM = 8  # small dimension for fast tests
+LIB = "lib1"
+
+
+def _make_store(tmp_dir: str) -> VectorStore:
+    return VectorStore(
+        storage_path=Path(tmp_dir) / "qdrant",
+        embedding_dim=DIM,
+        embedding_model_name="test-model",
+        distance=Distance.COSINE,
+    )
+
+
+def _unit_vec(index: int, dim: int = DIM) -> list[float]:
+    """Return a unit vector with 1.0 at `index` and 0.0 elsewhere."""
+    v = [0.0] * dim
+    v[index % dim] = 1.0
+    return v
+
+
+class TestCollectionsCreated(unittest.TestCase):
+    """Both new collections must be created by _ensure_collections()."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_item_vectors_collection_exists(self):
+        names = [c.name for c in self.store.client.get_collections().collections]
+        self.assertIn(VectorStore.ITEM_VECTORS_COLLECTION, names)
+
+    def test_collection_vectors_collection_exists(self):
+        names = [c.name for c in self.store.client.get_collections().collections]
+        self.assertIn(VectorStore.COLLECTION_VECTORS_COLLECTION, names)
+
+
+class TestItemVectorsCRUD(unittest.TestCase):
+    """upsert / get / list / count / delete for item_vectors."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_upsert_and_get_round_trip(self):
+        vec = _unit_vec(0)
+        pid = self.store.upsert_item_vector(
+            library_id=LIB,
+            item_key="ITEM1",
+            vector=vec,
+            collection_ids=["col1", "col2"],
+            source="abstract",
+            title="Test Title",
+        )
+        self.assertIsNotNone(pid)
+
+        result = self.store.get_item_vector(LIB, "ITEM1")
+        self.assertIsNotNone(result)
+        retrieved_vec, payload = result
+        self.assertEqual(retrieved_vec, vec)
+        self.assertEqual(payload["item_key"], "ITEM1")
+        self.assertEqual(payload["library_id"], LIB)
+        self.assertEqual(payload["collection_ids"], ["col1", "col2"])
+        self.assertEqual(payload["source"], "abstract")
+        self.assertEqual(payload["title"], "Test Title")
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertIn("computed_at", payload)
+
+    def test_upsert_is_idempotent(self):
+        """Upserting the same item twice should not create duplicates."""
+        for _ in range(2):
+            self.store.upsert_item_vector(LIB, "ITEM1", _unit_vec(0), [], "abstract", "T")
+        self.assertEqual(self.store.count_item_vectors(LIB), 1)
+
+    def test_get_item_vector_not_found(self):
+        result = self.store.get_item_vector(LIB, "MISSING")
+        self.assertIsNone(result)
+
+    def test_get_item_vectors_for_library(self):
+        for i in range(3):
+            self.store.upsert_item_vector(LIB, f"ITEM{i}", _unit_vec(i), [f"c{i}"], "abstract", f"T{i}")
+        # Add one item in a different library — must not appear
+        self.store.upsert_item_vector("lib2", "OTHER", _unit_vec(0), [], "abstract", "X")
+
+        items = self.store.get_item_vectors_for_library(LIB)
+        self.assertEqual(len(items), 3)
+        keys = {tup[0] for tup in items}
+        self.assertEqual(keys, {"ITEM0", "ITEM1", "ITEM2"})
+        # Each tuple has (item_key, vector, collection_ids)
+        for item_key, vec, col_ids in items:
+            self.assertIsInstance(vec, list)
+            self.assertEqual(len(vec), DIM)
+            self.assertIsInstance(col_ids, list)
+
+    def test_count_item_vectors(self):
+        self.assertEqual(self.store.count_item_vectors(LIB), 0)
+        self.store.upsert_item_vector(LIB, "ITEM1", _unit_vec(0), [], "abstract", "T")
+        self.assertEqual(self.store.count_item_vectors(LIB), 1)
+        self.store.upsert_item_vector(LIB, "ITEM2", _unit_vec(1), [], "abstract", "T")
+        self.assertEqual(self.store.count_item_vectors(LIB), 2)
+
+    def test_delete_item_vector(self):
+        self.store.upsert_item_vector(LIB, "ITEM1", _unit_vec(0), [], "abstract", "T")
+        deleted = self.store.delete_item_vector(LIB, "ITEM1")
+        self.assertEqual(deleted, 1)
+        self.assertIsNone(self.store.get_item_vector(LIB, "ITEM1"))
+        self.assertEqual(self.store.count_item_vectors(LIB), 0)
+
+    def test_delete_item_vector_not_found(self):
+        deleted = self.store.delete_item_vector(LIB, "GHOST")
+        self.assertEqual(deleted, 0)
+
+
+class TestGetChunkVectorsForItem(unittest.TestCase):
+    """get_chunk_vectors_for_item returns vectors from document_chunks."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _add_chunk(self, item_key: str, chunk_index: int, vector: list[float]):
+        chunk = DocumentChunk(
+            text=f"Text {chunk_index}",
+            metadata=ChunkMetadata(
+                chunk_id=f"{LIB}:{item_key}:{chunk_index}",
+                document_metadata=DocumentMetadata(
+                    library_id=LIB,
+                    item_key=item_key,
+                    title="Test",
+                ),
+                page_number=1,
+                text_preview="Text",
+                chunk_index=chunk_index,
+                content_hash=f"hash-{item_key}-{chunk_index}",
+            ),
+            embedding=vector,
+        )
+        self.store.add_chunk(chunk)
+
+    def test_returns_chunk_vectors(self):
+        vecs = [_unit_vec(i) for i in range(3)]
+        for i, v in enumerate(vecs):
+            self._add_chunk("ITEM1", i, v)
+
+        result = self.store.get_chunk_vectors_for_item(LIB, "ITEM1")
+        self.assertEqual(len(result), 3)
+        for v in result:
+            self.assertIsInstance(v, list)
+            self.assertEqual(len(v), DIM)
+
+    def test_returns_empty_for_unknown_item(self):
+        result = self.store.get_chunk_vectors_for_item(LIB, "GHOST")
+        self.assertEqual(result, [])
+
+
+class TestCollectionVectorsCRUD(unittest.TestCase):
+    """upsert / get / search / count / delete for collection_vectors."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_upsert_and_get_round_trip(self):
+        vec = _unit_vec(0)
+        pid = self.store.upsert_collection_vector(
+            library_id=LIB,
+            collection_id="COL1",
+            collection_name="Physics",
+            vector=vec,
+            item_count=42,
+        )
+        self.assertIsNotNone(pid)
+
+        result = self.store.get_collection_vector(LIB, "COL1")
+        self.assertIsNotNone(result)
+        retrieved_vec, payload = result
+        self.assertEqual(retrieved_vec, vec)
+        self.assertEqual(payload["collection_id"], "COL1")
+        self.assertEqual(payload["library_id"], LIB)
+        self.assertEqual(payload["collection_name"], "Physics")
+        self.assertEqual(payload["item_count"], 42)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertIn("computed_at", payload)
+
+    def test_upsert_is_idempotent(self):
+        for _ in range(2):
+            self.store.upsert_collection_vector(LIB, "COL1", "Physics", _unit_vec(0), 1)
+        self.assertEqual(self.store.count_collection_vectors(LIB), 1)
+
+    def test_get_collection_vector_not_found(self):
+        self.assertIsNone(self.store.get_collection_vector(LIB, "GHOST"))
+
+    def test_get_all_collection_vectors(self):
+        for i in range(3):
+            self.store.upsert_collection_vector(LIB, f"COL{i}", f"Col {i}", _unit_vec(i), i)
+        self.store.upsert_collection_vector("lib2", "COL_OTHER", "Other", _unit_vec(0), 0)
+
+        all_vecs = self.store.get_all_collection_vectors(LIB)
+        self.assertEqual(len(all_vecs), 3)
+        col_ids = {t[0] for t in all_vecs}
+        self.assertEqual(col_ids, {"COL0", "COL1", "COL2"})
+        for col_id, vec, payload in all_vecs:
+            self.assertIsInstance(vec, list)
+            self.assertEqual(len(vec), DIM)
+            self.assertIsInstance(payload, dict)
+
+    def test_search_collection_vectors_top_result(self):
+        """The closest collection should score highest."""
+        # COL0 vector is (1,0,0,...), COL1 vector is (0,1,0,...)
+        self.store.upsert_collection_vector(LIB, "COL0", "A", _unit_vec(0), 5)
+        self.store.upsert_collection_vector(LIB, "COL1", "B", _unit_vec(1), 3)
+
+        # Query along dimension 0 — COL0 should be #1
+        results = self.store.search_collection_vectors(_unit_vec(0), LIB, limit=2)
+        self.assertEqual(len(results), 2)
+        col_ids = [r[0] for r in results]
+        self.assertEqual(col_ids[0], "COL0")
+        # Scores are sorted descending
+        self.assertGreaterEqual(results[0][1], results[1][1])
+
+    def test_search_respects_library_filter(self):
+        self.store.upsert_collection_vector(LIB, "COL1", "Mine", _unit_vec(0), 1)
+        self.store.upsert_collection_vector("lib2", "COL2", "Theirs", _unit_vec(0), 1)
+
+        results = self.store.search_collection_vectors(_unit_vec(0), LIB, limit=10)
+        col_ids = [r[0] for r in results]
+        self.assertIn("COL1", col_ids)
+        self.assertNotIn("COL2", col_ids)
+
+    def test_count_collection_vectors(self):
+        self.assertEqual(self.store.count_collection_vectors(LIB), 0)
+        self.store.upsert_collection_vector(LIB, "COL1", "A", _unit_vec(0), 1)
+        self.assertEqual(self.store.count_collection_vectors(LIB), 1)
+
+    def test_delete_collection_vector(self):
+        self.store.upsert_collection_vector(LIB, "COL1", "A", _unit_vec(0), 1)
+        deleted = self.store.delete_collection_vector(LIB, "COL1")
+        self.assertEqual(deleted, 1)
+        self.assertIsNone(self.store.get_collection_vector(LIB, "COL1"))
+        self.assertEqual(self.store.count_collection_vectors(LIB), 0)
+
+    def test_delete_collection_vector_not_found(self):
+        deleted = self.store.delete_collection_vector(LIB, "GHOST")
+        self.assertEqual(deleted, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_collection_vector_store.py
+++ b/backend/tests/test_collection_vector_store.py
@@ -279,5 +279,63 @@ class TestCollectionVectorsCRUD(unittest.TestCase):
         self.assertEqual(deleted, 0)
 
 
+class TestDeleteLibraryItemVectors(unittest.TestCase):
+    """delete_library_item_vectors removes all item vectors for a library."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_deletes_all_item_vectors_for_library(self):
+        for i in range(3):
+            self.store.upsert_item_vector(LIB, f"ITEM{i}", _unit_vec(i), [], "abstract", f"T{i}")
+        # Add item in a different library — must not be deleted
+        self.store.upsert_item_vector("lib2", "OTHER", _unit_vec(0), [], "abstract", "X")
+
+        deleted = self.store.delete_library_item_vectors(LIB)
+
+        self.assertEqual(deleted, 3)
+        self.assertEqual(self.store.count_item_vectors(LIB), 0)
+        # Other library untouched
+        self.assertEqual(self.store.count_item_vectors("lib2"), 1)
+
+    def test_returns_zero_when_library_has_no_vectors(self):
+        deleted = self.store.delete_library_item_vectors("empty_lib")
+        self.assertEqual(deleted, 0)
+
+
+class TestDeleteLibraryCollectionVectors(unittest.TestCase):
+    """delete_library_collection_vectors removes all collection vectors for a library."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.store = _make_store(self.temp_dir)
+
+    def tearDown(self):
+        self.store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_deletes_all_collection_vectors_for_library(self):
+        for i in range(4):
+            self.store.upsert_collection_vector(LIB, f"COL{i}", f"Col {i}", _unit_vec(i), i)
+        # Add collection in a different library — must not be deleted
+        self.store.upsert_collection_vector("lib2", "COL_OTHER", "Other", _unit_vec(0), 0)
+
+        deleted = self.store.delete_library_collection_vectors(LIB)
+
+        self.assertEqual(deleted, 4)
+        self.assertEqual(self.store.count_collection_vectors(LIB), 0)
+        # Other library untouched
+        self.assertEqual(self.store.count_collection_vectors("lib2"), 1)
+
+    def test_returns_zero_when_library_has_no_vectors(self):
+        deleted = self.store.delete_library_collection_vectors("empty_lib")
+        self.assertEqual(deleted, 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_item_vector_pending.py
+++ b/backend/tests/test_item_vector_pending.py
@@ -1,0 +1,334 @@
+"""
+Tests for the item_vector_pending flag on DocumentUploadResult.
+
+Verifies:
+- Successful (fresh) indexing returns item_vector_pending=True
+- Duplicate-skip responses return item_vector_pending=False
+- Error responses return item_vector_pending=False
+- upload_and_index_abstract follows the same rules
+"""
+
+import dataclasses
+import json
+import unittest
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.api.document_upload import DocumentUploadResult
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_METADATA = json.dumps({
+    "library_id": "lib1",
+    "item_key": "ITEM001",
+    "attachment_key": "ATT001",
+    "mime_type": "application/pdf",
+    "item_version": 1,
+    "attachment_version": 1,
+    "title": "Test Item",
+    "authors": ["Author, A."],
+    "year": 2024,
+})
+
+
+def _mock_vector_store(*, is_duplicate: bool = False) -> MagicMock:
+    vs = MagicMock()
+    vs.check_duplicate.return_value = is_duplicate
+    vs.get_item_version.return_value = None
+    vs.delete_item_chunks.return_value = 0
+    vs.get_library_metadata.return_value = None
+    vs.count_library_chunks.return_value = 5
+    vs.update_library_metadata.return_value = None
+    return vs
+
+
+def _make_proc_result(status: str, chunks: int = 3):
+    """Return a minimal ProcessingResult-like object."""
+    r = MagicMock()
+    r.status = status
+    r.chunks_written = chunks
+    r.error_detail = None
+    return r
+
+
+# ---------------------------------------------------------------------------
+# DocumentUploadResult model field tests
+# ---------------------------------------------------------------------------
+
+class TestDocumentUploadResultField(unittest.TestCase):
+    """item_vector_pending must default to False and accept True."""
+
+    def test_default_is_false(self):
+        result = DocumentUploadResult(
+            library_id="lib1", item_key="K1", attachment_key="A1",
+            chunks_added=0, status="skipped_duplicate",
+        )
+        self.assertFalse(result.item_vector_pending)
+
+    def test_can_be_set_true(self):
+        result = DocumentUploadResult(
+            library_id="lib1", item_key="K1", attachment_key="A1",
+            chunks_added=5, status="indexed",
+            item_vector_pending=True,
+        )
+        self.assertTrue(result.item_vector_pending)
+
+    def test_serialises_in_json(self):
+        result = DocumentUploadResult(
+            library_id="lib1", item_key="K1", attachment_key="A1",
+            chunks_added=5, status="indexed",
+            item_vector_pending=True,
+        )
+        data = result.model_dump()
+        self.assertIn("item_vector_pending", data)
+        self.assertTrue(data["item_vector_pending"])
+
+
+# ---------------------------------------------------------------------------
+# Sync upload endpoint (/api/index/document)
+# ---------------------------------------------------------------------------
+
+class TestSyncUploadItemVectorPending(unittest.TestCase):
+
+    def setUp(self):
+        from backend.main import app
+        from backend.dependencies import get_vector_store
+        self.app = app
+        self.get_vector_store = get_vector_store
+        self.client = TestClient(app, raise_server_exceptions=False)
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+
+    def _post(self, pdf_bytes: bytes = b"%PDF fake"):
+        return self.client.post(
+            "/api/index/document",
+            files={"file": ("test.pdf", BytesIO(pdf_bytes), "application/pdf")},
+            data={"metadata": _METADATA},
+        )
+
+    def test_indexed_fresh_sets_item_vector_pending_true(self):
+        """A freshly indexed document must return item_vector_pending=True."""
+        self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store()
+
+        with (
+            patch("backend.api.document_upload._check_registration"),
+            patch("backend.api.document_upload.make_embedding_service") as mock_emb_factory,
+            patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
+        ):
+            mock_emb = MagicMock()
+            mock_emb.rate_limit_retries = 0
+            mock_emb.get_rate_limit_info = AsyncMock(return_value=None)
+            mock_emb_factory.return_value = mock_emb
+
+            mock_proc = MagicMock()
+            mock_proc_cls.return_value = mock_proc
+            mock_proc._process_attachment_bytes = AsyncMock(
+                return_value=_make_proc_result("indexed_fresh", chunks=3)
+            )
+
+            resp = self._post()
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "indexed")
+        self.assertTrue(data["item_vector_pending"], "indexed response must have item_vector_pending=True")
+
+    def test_duplicate_sets_item_vector_pending_false(self):
+        """A content-hash duplicate must return item_vector_pending=False."""
+        self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store(is_duplicate=True)
+
+        with patch("backend.api.document_upload._check_registration"):
+            resp = self._post()
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "skipped_duplicate")
+        self.assertFalse(data["item_vector_pending"], "duplicate response must have item_vector_pending=False")
+
+    def test_error_sets_item_vector_pending_false(self):
+        """An error response must return item_vector_pending=False."""
+        self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store()
+
+        with (
+            patch("backend.api.document_upload._check_registration"),
+            patch("backend.api.document_upload.make_embedding_service") as mock_emb_factory,
+            patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
+        ):
+            mock_emb = MagicMock()
+            mock_emb_factory.return_value = mock_emb
+
+            mock_proc = MagicMock()
+            mock_proc_cls.return_value = mock_proc
+            mock_proc._process_attachment_bytes = AsyncMock(
+                side_effect=RuntimeError("embedding service unavailable")
+            )
+
+            resp = self._post()
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "error")
+        self.assertFalse(data["item_vector_pending"], "error response must have item_vector_pending=False")
+
+    def test_skipped_empty_sets_item_vector_pending_false(self):
+        """A skipped_empty result (no text extracted) must return item_vector_pending=False."""
+        self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store()
+
+        with (
+            patch("backend.api.document_upload._check_registration"),
+            patch("backend.api.document_upload.make_embedding_service") as mock_emb_factory,
+            patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
+        ):
+            mock_emb = MagicMock()
+            mock_emb.rate_limit_retries = 0
+            mock_emb.get_rate_limit_info = AsyncMock(return_value=None)
+            mock_emb_factory.return_value = mock_emb
+
+            mock_proc = MagicMock()
+            mock_proc_cls.return_value = mock_proc
+            mock_proc._process_attachment_bytes = AsyncMock(
+                return_value=_make_proc_result("skipped_empty", chunks=0)
+            )
+
+            resp = self._post()
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "skipped_empty")
+        self.assertFalse(data["item_vector_pending"], "skipped_empty response must have item_vector_pending=False")
+
+
+# ---------------------------------------------------------------------------
+# Abstract index endpoint (/api/index/abstract)
+# ---------------------------------------------------------------------------
+
+_ABSTRACT_PAYLOAD = {
+    "library_id": "lib1",
+    "library_type": "user",
+    "item_key": "ITEM002",
+    "item_version": 1,
+    "title": "Abstract Test Item",
+    "authors": ["Doe, J."],
+    "year": 2023,
+    "item_type": "journalArticle",
+    "zotero_modified": "2023-01-01T00:00:00Z",
+    "abstract_text": (
+        "This study investigates the relationship between machine learning models and "
+        "information retrieval in academic research libraries. We present a novel approach "
+        "that combines dense vector embeddings with traditional keyword search to improve "
+        "recall and precision for scientific literature discovery. Our experiments on a "
+        "corpus of over one hundred thousand academic papers demonstrate statistically "
+        "significant improvements over baseline retrieval methods. The proposed system "
+        "integrates seamlessly with existing reference management workflows and requires "
+        "minimal configuration from end users. Results suggest that hybrid retrieval "
+        "strategies outperform single-modality approaches across all evaluated domains. "
+        "Future work will explore multilingual retrieval and cross-domain transfer learning "
+        "to further broaden the applicability of the proposed framework."
+    ),
+    "library_name": "Test Library",
+}
+
+
+class TestAbstractIndexItemVectorPending(unittest.TestCase):
+
+    def setUp(self):
+        from backend.main import app
+        from backend.dependencies import get_vector_store
+        self.app = app
+        self.get_vector_store = get_vector_store
+        self.client = TestClient(app, raise_server_exceptions=False)
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+
+    def _post(self, payload: dict | None = None):
+        return self.client.post(
+            "/api/index/abstract",
+            json=payload or _ABSTRACT_PAYLOAD,
+        )
+
+    def test_abstract_indexed_sets_item_vector_pending_true(self):
+        """Freshly indexed abstract must return item_vector_pending=True."""
+        self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store()
+
+        with (
+            patch("backend.api.document_upload._check_registration"),
+            patch("backend.api.document_upload.make_embedding_service") as mock_emb_factory,
+            patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
+        ):
+            mock_emb = MagicMock()
+            mock_emb.rate_limit_retries = 0
+            mock_emb.get_rate_limit_info = AsyncMock(return_value=None)
+            mock_emb_factory.return_value = mock_emb
+
+            mock_proc = MagicMock()
+            mock_proc_cls.return_value = mock_proc
+            # _index_from_abstract returns a chunk count (int)
+            mock_proc._index_from_abstract = AsyncMock(return_value=2)
+
+            resp = self._post()
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "indexed")
+        self.assertTrue(data["item_vector_pending"], "indexed abstract must have item_vector_pending=True")
+
+    def test_abstract_zero_chunks_sets_item_vector_pending_false(self):
+        """Abstract returning 0 chunks (treated as duplicate) must return item_vector_pending=False."""
+        self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store()
+
+        with (
+            patch("backend.api.document_upload._check_registration"),
+            patch("backend.api.document_upload.make_embedding_service") as mock_emb_factory,
+            patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
+        ):
+            mock_emb = MagicMock()
+            mock_emb.rate_limit_retries = 0
+            mock_emb.get_rate_limit_info = AsyncMock(return_value=None)
+            mock_emb_factory.return_value = mock_emb
+
+            mock_proc = MagicMock()
+            mock_proc_cls.return_value = mock_proc
+            mock_proc._index_from_abstract = AsyncMock(return_value=0)
+
+            resp = self._post()
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "skipped_duplicate")
+        self.assertFalse(data["item_vector_pending"], "skipped abstract must have item_vector_pending=False")
+
+    def test_abstract_error_sets_item_vector_pending_false(self):
+        """An error during abstract indexing must return item_vector_pending=False."""
+        self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store()
+
+        with (
+            patch("backend.api.document_upload._check_registration"),
+            patch("backend.api.document_upload.make_embedding_service") as mock_emb_factory,
+            patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
+        ):
+            mock_emb = MagicMock()
+            mock_emb_factory.return_value = mock_emb
+
+            mock_proc = MagicMock()
+            mock_proc_cls.return_value = mock_proc
+            mock_proc._index_from_abstract = AsyncMock(
+                side_effect=RuntimeError("embedding service failed")
+            )
+
+            resp = self._post()
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "error")
+        self.assertFalse(data["item_vector_pending"], "error abstract response must have item_vector_pending=False")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/src/api/collections.js
+++ b/plugin/src/api/collections.js
@@ -126,15 +126,10 @@ const CollectionsAPI = {
      */
     async suggestCollections(backendURL, libraryId, itemKey, getAuthHeaders, limit = 5) {
         const url = `${backendURL}/api/collections/suggest?library_id=${encodeURIComponent(libraryId)}&item_key=${encodeURIComponent(itemKey)}&limit=${encodeURIComponent(limit)}`;
-        let response;
-        try {
-            response = await _apiFetch('GET', url, {
-                headers: getAuthHeaders(),
-                statusAllowList: [404],
-            });
-        } catch (err) {
-            throw err;
-        }
+        const response = await _apiFetch('GET', url, {
+            headers: getAuthHeaders(),
+            statusAllowList: [404],
+        });
         if (response.status === 404) {
             return [];
         }

--- a/plugin/src/api/collections.js
+++ b/plugin/src/api/collections.js
@@ -64,7 +64,7 @@ async function _apiFetch(method, url, init = {}) {
  * @property {number} score
  */
 
-const CollectionsAPI = {
+var CollectionsAPI = {
     /**
      * Get the status of collection vectors for a library.
      *
@@ -114,8 +114,8 @@ const CollectionsAPI = {
     /**
      * Get collection suggestions for a given item.
      *
-     * Returns an empty array if the item vector does not exist yet (HTTP 404).
-     * Throws on all other HTTP errors.
+     * Returns an empty array when no item vector exists yet.
+     * Throws on HTTP errors.
      *
      * @param {string} backendURL - Base URL of the backend server
      * @param {string} libraryId - Zotero library identifier
@@ -128,11 +128,7 @@ const CollectionsAPI = {
         const url = `${backendURL}/api/collections/suggest?library_id=${encodeURIComponent(libraryId)}&item_key=${encodeURIComponent(itemKey)}&limit=${encodeURIComponent(limit)}`;
         const response = await _apiFetch('GET', url, {
             headers: getAuthHeaders(),
-            statusAllowList: [404],
         });
-        if (response.status === 404) {
-            return [];
-        }
         return /** @type {Array<CollectionSuggestion>} */ (await response.json());
     },
 };

--- a/plugin/src/api/collections.js
+++ b/plugin/src/api/collections.js
@@ -1,0 +1,143 @@
+// @ts-check
+
+/**
+ * API client for collection vector endpoints.
+ * @module api/collections
+ */
+
+/**
+ * Perform an HTTP request, throwing a descriptive Error on non-2xx responses.
+ *
+ * @param {string} method - HTTP method (GET, POST, etc.)
+ * @param {string} url - Full URL to fetch
+ * @param {RequestInit & {statusAllowList?: number[]}} [init] - Fetch init options, plus
+ *   an optional `statusAllowList` of HTTP status codes that should be returned as-is
+ *   rather than triggering an error throw.
+ * @returns {Promise<Response>}
+ */
+async function _apiFetch(method, url, init = {}) {
+    const { statusAllowList, ...fetchInit } = init;
+    const response = await fetch(url, { method, ...fetchInit });
+    if (!response.ok) {
+        // If caller explicitly whitelisted this status code, return it un-thrown.
+        if (statusAllowList && statusAllowList.includes(response.status)) {
+            return response;
+        }
+        let detail = '';
+        const ct = response.headers.get('content-type') || '';
+        if (ct.includes('application/json')) {
+            const body = /** @type {{detail?: string}} */ (
+                /** @type {unknown} */ (await response.json().catch(() => ({})))
+            );
+            detail = body.detail || JSON.stringify(body);
+        } else {
+            const text = await response.text().catch(() => '');
+            detail = text.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 200);
+        }
+        const path = (() => { try { return new URL(url).pathname; } catch (_) { return url; } })();
+        throw new Error(`${method} ${path}: HTTP ${response.status}${detail ? ` — ${detail}` : ''}`);
+    }
+    return response;
+}
+
+/**
+ * @typedef {Object} CollectionVectorsStatus
+ * @property {string} library_id
+ * @property {number} item_vectors_count
+ * @property {number} collection_vectors_count
+ * @property {boolean} computed
+ */
+
+/**
+ * @typedef {Object} SyncCollectionVectorsResult
+ * @property {number} items_computed
+ * @property {number} items_skipped
+ * @property {number} collections_computed
+ * @property {number} collections_skipped
+ */
+
+/**
+ * @typedef {Object} CollectionSuggestion
+ * @property {string} collection_id
+ * @property {string} collection_name
+ * @property {string} library_id
+ * @property {number} score
+ */
+
+const CollectionsAPI = {
+    /**
+     * Get the status of collection vectors for a library.
+     *
+     * @param {string} backendURL - Base URL of the backend server
+     * @param {string} libraryId - Zotero library identifier
+     * @param {function(Record<string,string>=): Record<string,string>} getAuthHeaders - Returns auth headers
+     * @returns {Promise<CollectionVectorsStatus>}
+     */
+    async getCollectionVectorsStatus(backendURL, libraryId, getAuthHeaders) {
+        const url = `${backendURL}/api/collections/vectors/status?library_id=${encodeURIComponent(libraryId)}`;
+        const response = await _apiFetch('GET', url, {
+            headers: getAuthHeaders(),
+        });
+        return /** @type {CollectionVectorsStatus} */ (await response.json());
+    },
+
+    /**
+     * Sync collection membership vectors to the backend.
+     *
+     * @param {string} backendURL - Base URL of the backend server
+     * @param {string} libraryId - Zotero library identifier
+     * @param {Object.<string, string[]>} collectionMap - Maps item_key to list of collection_ids
+     * @param {Object.<string, string>} collectionNames - Maps collection_id to collection name
+     * @param {function(Record<string,string>=): Record<string,string>} getAuthHeaders - Returns auth headers
+     * @param {AbortSignal} [signal] - Optional AbortSignal for cancellation
+     * @returns {Promise<SyncCollectionVectorsResult>}
+     */
+    async syncCollectionVectors(backendURL, libraryId, collectionMap, collectionNames, getAuthHeaders, signal) {
+        const url = `${backendURL}/api/collections/vectors/sync`;
+        const body = JSON.stringify({
+            library_id: libraryId,
+            collection_map: collectionMap,
+            collection_names: collectionNames,
+        });
+        /** @type {RequestInit & {statusAllowList?: number[]}} */
+        const init = {
+            headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
+            body,
+        };
+        if (signal !== undefined) {
+            init.signal = signal;
+        }
+        const response = await _apiFetch('POST', url, init);
+        return /** @type {SyncCollectionVectorsResult} */ (await response.json());
+    },
+
+    /**
+     * Get collection suggestions for a given item.
+     *
+     * Returns an empty array if the item vector does not exist yet (HTTP 404).
+     * Throws on all other HTTP errors.
+     *
+     * @param {string} backendURL - Base URL of the backend server
+     * @param {string} libraryId - Zotero library identifier
+     * @param {string} itemKey - Zotero item key
+     * @param {function(Record<string,string>=): Record<string,string>} getAuthHeaders - Returns auth headers
+     * @param {number} [limit=5] - Maximum number of suggestions to return
+     * @returns {Promise<Array<CollectionSuggestion>>}
+     */
+    async suggestCollections(backendURL, libraryId, itemKey, getAuthHeaders, limit = 5) {
+        const url = `${backendURL}/api/collections/suggest?library_id=${encodeURIComponent(libraryId)}&item_key=${encodeURIComponent(itemKey)}&limit=${encodeURIComponent(limit)}`;
+        let response;
+        try {
+            response = await _apiFetch('GET', url, {
+                headers: getAuthHeaders(),
+                statusAllowList: [404],
+            });
+        } catch (err) {
+            throw err;
+        }
+        if (response.status === 404) {
+            return [];
+        }
+        return /** @type {Array<CollectionSuggestion>} */ (await response.json());
+    },
+};

--- a/plugin/src/bootstrap.js
+++ b/plugin/src/bootstrap.js
@@ -36,9 +36,10 @@ async function startup({ id, version, rootURI }) {
 	Services.scriptloader.loadSubScript(rootURI + 'zotero-rag.js');
 	Services.scriptloader.loadSubScript(rootURI + 'preferences.js');
 
-	// Load collections API client and filing suggestions UI
+	// Load collections API client, filing suggestions UI, and item navigation
 	Services.scriptloader.loadSubScript(rootURI + 'api/collections.js');
 	Services.scriptloader.loadSubScript(rootURI + 'ui/collection_suggestions.js');
+	Services.scriptloader.loadSubScript(rootURI + 'ui/item_navigation.js');
 
 	ZoteroRAG.init({ id, version, rootURI });
 	Zotero.ZoteroRAG = ZoteroRAG;
@@ -47,6 +48,8 @@ async function startup({ id, version, rootURI }) {
 
 	// Register the item pane section for filing suggestions
 	registerFilingSuggestionsPane();
+	// Register item navigation (Back/Forward buttons)
+	registerItemNavigation();
 }
 
 function onMainWindowLoad({ window }) {
@@ -62,6 +65,8 @@ function shutdown() {
 
 	// Unregister the filing suggestions item pane section
 	try { unregisterFilingSuggestionsPane(); } catch (_) {}
+	// Unregister item navigation
+	try { unregisterItemNavigation(); } catch (_) {}
 
 	if (ZoteroRAG) {
 		ZoteroRAG.removeFromAllWindows();

--- a/plugin/src/bootstrap.js
+++ b/plugin/src/bootstrap.js
@@ -35,10 +35,18 @@ async function startup({ id, version, rootURI }) {
 	// Load main plugin script and preferences pane logic
 	Services.scriptloader.loadSubScript(rootURI + 'zotero-rag.js');
 	Services.scriptloader.loadSubScript(rootURI + 'preferences.js');
+
+	// Load collections API client and filing suggestions UI
+	Services.scriptloader.loadSubScript(rootURI + 'api/collections.js');
+	Services.scriptloader.loadSubScript(rootURI + 'ui/collection_suggestions.js');
+
 	ZoteroRAG.init({ id, version, rootURI });
 	Zotero.ZoteroRAG = ZoteroRAG;
 	ZoteroRAG.addToAllWindows();
 	await ZoteroRAG.main();
+
+	// Register the item pane section for filing suggestions
+	registerFilingSuggestionsPane();
 }
 
 function onMainWindowLoad({ window }) {
@@ -51,6 +59,9 @@ function onMainWindowUnload({ window }) {
 
 function shutdown() {
 	log("Shutting down");
+
+	// Unregister the filing suggestions item pane section
+	try { unregisterFilingSuggestionsPane(); } catch (_) {}
 
 	if (ZoteroRAG) {
 		ZoteroRAG.removeFromAllWindows();

--- a/plugin/src/dialog.xhtml
+++ b/plugin/src/dialog.xhtml
@@ -19,6 +19,16 @@
         console.error("Failed to load include.js:", e);
       }
 
+      // Load collections API client (needed by remote_indexer for stage 7)
+      try {
+        Services.scriptloader.loadSubScript(
+          "chrome://zotero-rag/content/api/collections.js",
+          window
+        );
+      } catch (e) {
+        console.error("Failed to load api/collections.js:", e);
+      }
+
       // Load remote indexer (must load before dialog.js)
       try {
         Services.scriptloader.loadSubScript(

--- a/plugin/src/locale/en-US/zotero-rag.ftl
+++ b/plugin/src/locale/en-US/zotero-rag.ftl
@@ -2,4 +2,6 @@
 
 zotero-rag-ask-question = Ask Question...
 pane-filing-suggestions = Filing Suggestions
+pane-filing-suggestions-title = Suggested collections
 pane-filing-suggestions-empty = No suggestions yet. Index this item first.
+pane-item-navigation = Item Navigation

--- a/plugin/src/locale/en-US/zotero-rag.ftl
+++ b/plugin/src/locale/en-US/zotero-rag.ftl
@@ -1,3 +1,5 @@
 # Zotero RAG Plugin Localization (English)
 
 zotero-rag-ask-question = Ask Question...
+pane-filing-suggestions = Filing Suggestions
+pane-filing-suggestions-empty = No suggestions yet. Index this item first.

--- a/plugin/src/remote_indexer.js
+++ b/plugin/src/remote_indexer.js
@@ -492,10 +492,21 @@ var RemoteIndexer = {
 				if (_zoteroLibraryID) {
 					// Build collection membership map from the local Zotero database
 					const { collectionMap, collectionNames } = await this._buildCollectionMap(_zoteroLibraryID);
-					await CollectionsAPI.syncCollectionVectors(
+					// BEGIN DEBUG
+					const collectionMapSize = Object.keys(collectionMap).length;
+					const uniqueCollections = new Set(Object.values(collectionMap).flat());
+					log(`[RemoteIndexer] [DIAG] collection sync: libraryId=${libraryId} zoteroLibraryID=${_zoteroLibraryID} items_in_map=${collectionMapSize} unique_collections=${uniqueCollections.size}`);
+					if (collectionMapSize === 0) {
+						log(`[RemoteIndexer] [DIAG] collection sync: collectionMap is empty — no items in collections? Skipping sync.`);
+					}
+					// END DEBUG
+					const syncStats = await CollectionsAPI.syncCollectionVectors(
 						backendURL, libraryId, collectionMap, collectionNames,
 						getAuthHeaders, signal,
 					);
+					// BEGIN DEBUG
+					log(`[RemoteIndexer] [DIAG] collection sync result: ${JSON.stringify(syncStats)}`);
+					// END DEBUG
 					log(`[RemoteIndexer] Collection vectors synced`);
 				}
 			} catch (err) {
@@ -1326,9 +1337,17 @@ var RemoteIndexer = {
 		const search = new Zotero.Search();
 		(/** @type {any} */ (search)).libraryID = zoteroLibraryID;
 		const itemIDs = await search.search();
+		// BEGIN DEBUG
+		console.log(`[RemoteIndexer] [DIAG] _buildCollectionMap: zoteroLibraryID=${zoteroLibraryID} search returned ${itemIDs.length} item IDs`);
+		// END DEBUG
 		if (!itemIDs.length) return { collectionMap: {}, collectionNames: {} };
 
 		const items = await Zotero.Items.getAsync(itemIDs);
+		// BEGIN DEBUG
+		const regularItems = items.filter((/** @type {any} */ i) => !i.isAttachment() && !i.isNote());
+		const unfiledItems = regularItems.filter((/** @type {any} */ i) => !i.getCollections().length);
+		console.log(`[RemoteIndexer] [DIAG] _buildCollectionMap: total=${items.length} regular=${regularItems.length} unfiled=${unfiledItems.length} (unfiled excluded from sync)`);
+		// END DEBUG
 		/** @type {Object.<string, string[]>} */
 		const collectionMap = {};
 		/** @type {Object.<string, string>} */

--- a/plugin/src/remote_indexer.js
+++ b/plugin/src/remote_indexer.js
@@ -469,6 +469,9 @@ var RemoteIndexer = {
 		]);
 
 		// 7. Compute collection vectors (non-blocking — failure does not affect indexing result)
+		// TODO: Use item_vector_pending from upload responses to call the per-item update endpoint
+		//       (POST /api/collections/vectors/update-item) instead of a full sync, making
+		//       incremental runs O(new_items) instead of O(library_size).
 		if (!isCancelled() && typeof CollectionsAPI !== 'undefined') {
 			try {
 				onProgress({
@@ -1334,6 +1337,7 @@ var RemoteIndexer = {
 		for (const item of items) {
 			if (item.isAttachment() || item.isNote()) continue;
 			const colIDs = item.getCollections(); // returns array of internal integer IDs
+			// Unfiled items are intentionally excluded: no collection membership → no suggestion signal.
 			if (!colIDs.length) continue;
 			const colKeys = [];
 			for (const colID of colIDs) {

--- a/plugin/src/remote_indexer.js
+++ b/plugin/src/remote_indexer.js
@@ -468,6 +468,38 @@ var RemoteIndexer = {
 			this._savePendingCache(libraryId, pendingCache),
 		]);
 
+		// 7. Compute collection vectors (non-blocking — failure does not affect indexing result)
+		if (!isCancelled() && typeof CollectionsAPI !== 'undefined') {
+			try {
+				onProgress({
+					percentage: 100,
+					message: 'Computing filing suggestions...',
+					current: total,
+					total,
+				});
+				// Resolve Zotero-internal library ID (same logic as _collectAbstractItems)
+				let _zoteroLibraryID;
+				if (libraryType === 'group') {
+					const _group = Zotero.Groups.get(parseInt(libraryId, 10));
+					_zoteroLibraryID = _group ? _group.libraryID : null;
+				} else {
+					_zoteroLibraryID = Zotero.Libraries.userLibraryID;
+				}
+
+				if (_zoteroLibraryID) {
+					// Build collection membership map from the local Zotero database
+					const { collectionMap, collectionNames } = await this._buildCollectionMap(_zoteroLibraryID);
+					await CollectionsAPI.syncCollectionVectors(
+						backendURL, libraryId, collectionMap, collectionNames,
+						getAuthHeaders, signal,
+					);
+					log(`[RemoteIndexer] Collection vectors synced`);
+				}
+			} catch (err) {
+				log(`[RemoteIndexer] Collection vector sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+
 		const unreadable = skippedEmpty + skippedTimeout + parseErrors;
 		onProgress({
 			percentage: 100,
@@ -1278,5 +1310,43 @@ var RemoteIndexer = {
 		} catch (_) {
 			return null;
 		}
+	},
+
+	/**
+	 * Build a collection membership map for all regular items in a Zotero library.
+	 * Used by stage 7 to sync collection vectors to the backend after indexing.
+	 *
+	 * @param {number} zoteroLibraryID - Internal Zotero library ID
+	 * @returns {Promise<{collectionMap: Object.<string, string[]>, collectionNames: Object.<string, string>}>}
+	 */
+	async _buildCollectionMap(zoteroLibraryID) {
+		const search = new Zotero.Search();
+		(/** @type {any} */ (search)).libraryID = zoteroLibraryID;
+		const itemIDs = await search.search();
+		if (!itemIDs.length) return { collectionMap: {}, collectionNames: {} };
+
+		const items = await Zotero.Items.getAsync(itemIDs);
+		/** @type {Object.<string, string[]>} */
+		const collectionMap = {};
+		/** @type {Object.<string, string>} */
+		const collectionNames = {};
+
+		for (const item of items) {
+			if (item.isAttachment() || item.isNote()) continue;
+			const colIDs = item.getCollections(); // returns array of internal integer IDs
+			if (!colIDs.length) continue;
+			const colKeys = [];
+			for (const colID of colIDs) {
+				const col = Zotero.Collections.get(colID);
+				if (col) {
+					colKeys.push(col.key);
+					collectionNames[col.key] = col.name;
+				}
+			}
+			if (colKeys.length) {
+				collectionMap[item.key] = colKeys;
+			}
+		}
+		return { collectionMap, collectionNames };
 	},
 };

--- a/plugin/src/ui/collection_suggestions.js
+++ b/plugin/src/ui/collection_suggestions.js
@@ -16,8 +16,8 @@
  * - If no suggestions are available, an empty-state message is shown
  */
 
-const PANE_ID = "zotero-rag-filing-suggestions";
-const PLUGIN_ID = "zotero-rag@cboulanger.github.io";
+var PANE_ID = "zotero-rag-filing-suggestions";
+var PLUGIN_ID = "zotero-rag@cboulanger.github.io";
 
 /**
  * Derive the backend library ID for a given Zotero item.
@@ -135,7 +135,9 @@ async function _moveItemToCollection(item, collectionKey) {
     const currentCollections = item.getCollections(); // returns array of internal IDs
     item.addToCollection(col.id);
     for (const existingId of currentCollections) {
-        item.removeFromCollection(existingId);
+        if (existingId !== col.id) {  // don't remove the collection we just added
+            item.removeFromCollection(existingId);
+        }
     }
     await item.saveTx();
 }

--- a/plugin/src/ui/collection_suggestions.js
+++ b/plugin/src/ui/collection_suggestions.js
@@ -53,7 +53,51 @@ function _injectStyles(doc) {
         .rag-suggestion-row:hover .rag-actions { display: flex; }
         .rag-suggestion-row .rag-actions button { font-size: 0.8em; padding: 1px 6px; }
     `;
-    doc.head.appendChild(style);
+    (doc.head || doc.documentElement).appendChild(style);
+}
+
+/**
+ * Convert a backend library ID string (e.g. "u12345" or "6297749") to Zotero's
+ * internal numeric libraryID.  Returns null when the library can't be resolved.
+ *
+ * @param {string} backendLibraryId
+ * @returns {number|null}
+ */
+function _resolveZoteroLibraryID(backendLibraryId) {
+    if (backendLibraryId.startsWith('u')) {
+        return Zotero.Libraries.userLibraryID;
+    }
+    const groupId = parseInt(backendLibraryId, 10);
+    if (!isNaN(groupId)) {
+        const group = Zotero.Groups.get(groupId);
+        return group ? group.libraryID : null;
+    }
+    return null;
+}
+
+/**
+ * Build the full breadcrumb path for a collection: "Library / Parent / Collection".
+ * Falls back to `fallbackName` if the collection can't be resolved in the local Zotero DB.
+ *
+ * @param {string} backendLibraryId - Backend library ID from the suggestion
+ * @param {string} collectionKey - Zotero collection key
+ * @param {string} fallbackName - Name to use when the collection isn't found locally
+ * @returns {string}
+ */
+function _buildCollectionPath(backendLibraryId, collectionKey, fallbackName) {
+    const zoteroLibraryID = _resolveZoteroLibraryID(backendLibraryId);
+    if (zoteroLibraryID === null) return fallbackName || collectionKey;
+    const parts = [];
+    let col = Zotero.Collections.getByLibraryAndKey(zoteroLibraryID, collectionKey);
+    if (!col) return fallbackName || collectionKey;
+    while (col) {
+        parts.unshift(col.name);
+        if (!col.parentKey) break;
+        col = Zotero.Collections.getByLibraryAndKey(zoteroLibraryID, col.parentKey);
+    }
+    const lib = Zotero.Libraries.get(zoteroLibraryID);
+    if (lib) parts.unshift(lib.name);
+    return parts.join(' / ');
 }
 
 /**
@@ -77,7 +121,7 @@ function _buildSuggestionRow(suggestion, item, doc) {
 
     const label = doc.createElement("span");
     label.className = "label";
-    label.textContent = suggestion.collection_name || suggestion.collection_id;
+    label.textContent = _buildCollectionPath(suggestion.library_id, suggestion.collection_id, suggestion.collection_name);
 
     const score = doc.createElement("span");
     score.className = "rag-score";
@@ -91,14 +135,14 @@ function _buildSuggestionRow(suggestion, item, doc) {
     const copyBtn = doc.createElement("button");
     copyBtn.textContent = "Copy";
     copyBtn.onclick = async () => {
-        await _copyItemToCollection(item, suggestion.collection_id);
+        await _copyItemToCollection(item, suggestion.library_id, suggestion.collection_id);
         row.remove();
     };
 
     const moveBtn = doc.createElement("button");
     moveBtn.textContent = "Move";
     moveBtn.onclick = async () => {
-        await _moveItemToCollection(item, suggestion.collection_id);
+        await _moveItemToCollection(item, suggestion.library_id, suggestion.collection_id);
         row.remove();
     };
 
@@ -111,11 +155,14 @@ function _buildSuggestionRow(suggestion, item, doc) {
  * Add the item to a collection without removing it from existing collections.
  *
  * @param {any} item - Zotero item
+ * @param {string} backendLibraryId - Backend library ID of the target collection
  * @param {string} collectionKey - Zotero collection key (e.g. "ABC12345")
  * @returns {Promise<void>}
  */
-async function _copyItemToCollection(item, collectionKey) {
-    const col = Zotero.Collections.getByLibraryAndKey(item.libraryID, collectionKey);
+async function _copyItemToCollection(item, backendLibraryId, collectionKey) {
+    const zoteroLibraryID = _resolveZoteroLibraryID(backendLibraryId);
+    if (zoteroLibraryID === null) return;
+    const col = Zotero.Collections.getByLibraryAndKey(zoteroLibraryID, collectionKey);
     if (!col) return;
     item.addToCollection(col.id);
     await item.saveTx();
@@ -125,11 +172,14 @@ async function _copyItemToCollection(item, collectionKey) {
  * Move the item to a collection, removing it from all existing collections first.
  *
  * @param {any} item - Zotero item
+ * @param {string} backendLibraryId - Backend library ID of the target collection
  * @param {string} collectionKey - Zotero collection key (e.g. "ABC12345")
  * @returns {Promise<void>}
  */
-async function _moveItemToCollection(item, collectionKey) {
-    const col = Zotero.Collections.getByLibraryAndKey(item.libraryID, collectionKey);
+async function _moveItemToCollection(item, backendLibraryId, collectionKey) {
+    const zoteroLibraryID = _resolveZoteroLibraryID(backendLibraryId);
+    if (zoteroLibraryID === null) return;
+    const col = Zotero.Collections.getByLibraryAndKey(zoteroLibraryID, collectionKey);
     if (!col) return;
     // Capture existing collection IDs before modifying
     const currentCollections = item.getCollections(); // returns array of internal IDs
@@ -147,16 +197,16 @@ async function _moveItemToCollection(item, collectionKey) {
  * Called from bootstrap.js after ZoteroRAG.main() completes.
  */
 function registerFilingSuggestionsPane() {
-    Zotero.ItemPaneManager.registerSection({
+    const result = Zotero.ItemPaneManager.registerSection({
         paneID: PANE_ID,
         pluginID: PLUGIN_ID,
         header: {
             l10nID: "pane-filing-suggestions",
-            icon: "chrome://zotero/skin/default/zotero/16/universal/copy-collection.svg",
+            icon: "chrome://zotero/skin/16/universal/copy-collection.svg",
         },
         sidenav: {
             l10nID: "pane-filing-suggestions",
-            icon: "chrome://zotero/skin/default/zotero/itempane/20/libraries-collections.svg",
+            icon: "chrome://zotero/skin/20/universal/add-collection.svg",
         },
 
         // onRender is required by Zotero.ItemPaneManager; async work goes in onAsyncRender.
@@ -168,15 +218,32 @@ function registerFilingSuggestionsPane() {
         onAsyncRender: async ({ body, item, doc }) => {
             body.innerHTML = "";
 
+            // BEGIN DEBUG
+            console.log("[FilingSuggestions] onAsyncRender called " + JSON.stringify({
+                hasItem: !!item,
+                isAttachment: item?.isAttachment?.(),
+                isNote: item?.isNote?.(),
+                hasRAG: !!/** @type {any} */ (Zotero).ZoteroRAG,
+                backendURL: /** @type {any} */ (Zotero).ZoteroRAG?.backendURL,
+                hasCollectionsAPI: typeof CollectionsAPI !== 'undefined',
+                itemKey: item?.key,
+            }));
+            // END DEBUG
+
             // Only show for regular (non-attachment, non-note) items
             if (!item || item.isAttachment() || item.isNote()) {
+                console.log("[FilingSuggestions] skipping: attachment or note"); // DEBUG
                 return;
             }
 
             const rag = Zotero.ZoteroRAG;
-            if (!rag?.backendURL) return;
+            if (!rag?.backendURL) {
+                console.log("[FilingSuggestions] skipping: no backendURL"); // DEBUG
+                return;
+            }
 
             const libraryId = _getBackendLibraryId(item);
+            console.log("[FilingSuggestions] fetching suggestions for", item.key, "library", libraryId); // DEBUG
 
             let suggestions;
             try {
@@ -187,7 +254,9 @@ function registerFilingSuggestionsPane() {
                     (...args) => rag.getAuthHeaders(...args),
                     5,
                 );
+                console.log("[FilingSuggestions] suggestions:", JSON.stringify(suggestions)); // DEBUG
             } catch (err) {
+                console.error("[FilingSuggestions] fetch error:", err); // DEBUG
                 // Show an inline error rather than crashing the pane
                 const errDiv = doc.createElement("div");
                 errDiv.className = "rag-suggestions-empty";
@@ -212,6 +281,7 @@ function registerFilingSuggestionsPane() {
             }
         },
     });
+    console.log("[FilingSuggestions] registerSection result:", result); // DEBUG
 }
 
 /**

--- a/plugin/src/ui/collection_suggestions.js
+++ b/plugin/src/ui/collection_suggestions.js
@@ -1,0 +1,216 @@
+// @ts-check
+
+/**
+ * Filing suggestions item pane section for Zotero RAG.
+ *
+ * Registers a custom item pane section via Zotero.ItemPaneManager.registerSection()
+ * that queries the backend for collection filing suggestions for the selected item.
+ *
+ * Manual verification:
+ * - Select a regular item in Zotero that has been indexed by zotero-rag
+ * - The "Filing Suggestions" pane should appear in the item details panel
+ * - Each suggestion row shows collection name, similarity score, Copy and Move buttons
+ * - Hovering over a row reveals the action buttons
+ * - Copy adds the item to the suggested collection (item stays in current collections)
+ * - Move adds the item to the suggested collection and removes it from all existing collections
+ * - If no suggestions are available, an empty-state message is shown
+ */
+
+const PANE_ID = "zotero-rag-filing-suggestions";
+const PLUGIN_ID = "zotero-rag@cboulanger.github.io";
+
+/**
+ * Derive the backend library ID for a given Zotero item.
+ * Group libraries use the numeric group ID; the user library uses "u<userId>".
+ *
+ * @param {any} item - Zotero item
+ * @returns {string} Backend library identifier
+ */
+function _getBackendLibraryId(item) {
+    const lib = Zotero.Libraries.get(item.libraryID);
+    if (lib && lib.libraryType === 'group') {
+        const group = Zotero.Groups.getByLibraryID(item.libraryID);
+        return group ? String(group.id) : String(item.libraryID);
+    }
+    const userId = Zotero.Users.getCurrentUserID();
+    return userId ? `u${userId}` : String(item.libraryID);
+}
+
+/**
+ * Inject the suggestion-row stylesheet once per document.
+ *
+ * @param {Document} doc
+ */
+function _injectStyles(doc) {
+    if (doc.getElementById("rag-suggestions-style")) return;
+    const style = doc.createElement("style");
+    style.id = "rag-suggestions-style";
+    style.textContent = `
+        .rag-suggestion-row { display: flex; align-items: center; padding: 2px 4px; }
+        .rag-suggestion-row .box { flex: 1; display: flex; align-items: center; gap: 4px; }
+        .rag-suggestion-row .rag-score { font-size: 0.85em; opacity: 0.7; margin-left: 4px; }
+        .rag-suggestion-row .rag-actions { display: none; gap: 4px; }
+        .rag-suggestion-row:hover .rag-actions { display: flex; }
+        .rag-suggestion-row .rag-actions button { font-size: 0.8em; padding: 1px 6px; }
+    `;
+    doc.head.appendChild(style);
+}
+
+/**
+ * Build a single suggestion row element.
+ *
+ * @param {import('../api/collections.js').CollectionSuggestion} suggestion
+ * @param {any} item - Zotero item
+ * @param {Document} doc
+ * @returns {HTMLElement}
+ */
+function _buildSuggestionRow(suggestion, item, doc) {
+    const row = /** @type {HTMLElement} */ (doc.createElement("div"));
+    row.className = "rag-suggestion-row";
+    row.dataset.collectionKey = suggestion.collection_id;
+
+    const box = doc.createElement("div");
+    box.className = "box";
+
+    const icon = doc.createElement("span");
+    icon.className = "icon icon-css icon-collection";
+
+    const label = doc.createElement("span");
+    label.className = "label";
+    label.textContent = suggestion.collection_name || suggestion.collection_id;
+
+    const score = doc.createElement("span");
+    score.className = "rag-score";
+    score.textContent = `${Math.round(suggestion.score * 100)}%`;
+
+    box.append(icon, label, score);
+
+    const actions = doc.createElement("div");
+    actions.className = "rag-actions";
+
+    const copyBtn = doc.createElement("button");
+    copyBtn.textContent = "Copy";
+    copyBtn.onclick = async () => {
+        await _copyItemToCollection(item, suggestion.collection_id);
+        row.remove();
+    };
+
+    const moveBtn = doc.createElement("button");
+    moveBtn.textContent = "Move";
+    moveBtn.onclick = async () => {
+        await _moveItemToCollection(item, suggestion.collection_id);
+        row.remove();
+    };
+
+    actions.append(copyBtn, moveBtn);
+    row.append(box, actions);
+    return row;
+}
+
+/**
+ * Add the item to a collection without removing it from existing collections.
+ *
+ * @param {any} item - Zotero item
+ * @param {string} collectionKey - Zotero collection key (e.g. "ABC12345")
+ * @returns {Promise<void>}
+ */
+async function _copyItemToCollection(item, collectionKey) {
+    const col = Zotero.Collections.getByLibraryAndKey(item.libraryID, collectionKey);
+    if (!col) return;
+    item.addToCollection(col.id);
+    await item.saveTx();
+}
+
+/**
+ * Move the item to a collection, removing it from all existing collections first.
+ *
+ * @param {any} item - Zotero item
+ * @param {string} collectionKey - Zotero collection key (e.g. "ABC12345")
+ * @returns {Promise<void>}
+ */
+async function _moveItemToCollection(item, collectionKey) {
+    const col = Zotero.Collections.getByLibraryAndKey(item.libraryID, collectionKey);
+    if (!col) return;
+    // Capture existing collection IDs before modifying
+    const currentCollections = item.getCollections(); // returns array of internal IDs
+    item.addToCollection(col.id);
+    for (const existingId of currentCollections) {
+        item.removeFromCollection(existingId);
+    }
+    await item.saveTx();
+}
+
+/**
+ * Register the filing suggestions item pane section.
+ * Called from bootstrap.js after ZoteroRAG.main() completes.
+ */
+function registerFilingSuggestionsPane() {
+    Zotero.ItemPaneManager.registerSection({
+        paneID: PANE_ID,
+        pluginID: PLUGIN_ID,
+        header: {
+            l10nID: "pane-filing-suggestions",
+        },
+        sidenav: {
+            l10nID: "pane-filing-suggestions",
+        },
+
+        /**
+         * @param {{ body: HTMLElement, item: any, doc: Document }} renderCtx
+         */
+        onAsyncRender: async ({ body, item, doc }) => {
+            body.innerHTML = "";
+
+            // Only show for regular (non-attachment, non-note) items
+            if (!item || item.isAttachment() || item.isNote()) {
+                return;
+            }
+
+            const rag = Zotero.ZoteroRAG;
+            if (!rag?.backendURL) return;
+
+            const libraryId = _getBackendLibraryId(item);
+
+            let suggestions;
+            try {
+                suggestions = await CollectionsAPI.suggestCollections(
+                    rag.backendURL,
+                    libraryId,
+                    item.key,
+                    (...args) => rag.getAuthHeaders(...args),
+                    5,
+                );
+            } catch (err) {
+                // Show an inline error rather than crashing the pane
+                const errDiv = doc.createElement("div");
+                errDiv.className = "rag-suggestions-empty";
+                errDiv.textContent = `Error loading suggestions: ${err instanceof Error ? err.message : String(err)}`;
+                body.appendChild(errDiv);
+                return;
+            }
+
+            // Inject styles once per document (idempotent)
+            _injectStyles(doc);
+
+            if (!suggestions.length) {
+                const empty = doc.createElement("div");
+                empty.className = "rag-suggestions-empty";
+                empty.setAttribute("data-l10n-id", "pane-filing-suggestions-empty");
+                body.appendChild(empty);
+                return;
+            }
+
+            for (const suggestion of suggestions) {
+                body.appendChild(_buildSuggestionRow(suggestion, item, doc));
+            }
+        },
+    });
+}
+
+/**
+ * Unregister the filing suggestions item pane section.
+ * Called from bootstrap.js during shutdown.
+ */
+function unregisterFilingSuggestionsPane() {
+    Zotero.ItemPaneManager.unregisterSection(PANE_ID);
+}

--- a/plugin/src/ui/collection_suggestions.js
+++ b/plugin/src/ui/collection_suggestions.js
@@ -152,10 +152,15 @@ function registerFilingSuggestionsPane() {
         pluginID: PLUGIN_ID,
         header: {
             l10nID: "pane-filing-suggestions",
+            icon: "chrome://zotero/skin/default/zotero/16/universal/copy-collection.svg",
         },
         sidenav: {
             l10nID: "pane-filing-suggestions",
+            icon: "chrome://zotero/skin/default/zotero/itempane/20/libraries-collections.svg",
         },
+
+        // onRender is required by Zotero.ItemPaneManager; async work goes in onAsyncRender.
+        onRender: () => {},
 
         /**
          * @param {{ body: HTMLElement, item: any, doc: Document }} renderCtx

--- a/plugin/src/ui/collection_suggestions.js
+++ b/plugin/src/ui/collection_suggestions.js
@@ -46,12 +46,18 @@ function _injectStyles(doc) {
     const style = doc.createElement("style");
     style.id = "rag-suggestions-style";
     style.textContent = `
-        .rag-suggestion-row { display: flex; align-items: center; padding: 2px 4px; }
-        .rag-suggestion-row .box { flex: 1; display: flex; align-items: center; gap: 4px; }
-        .rag-suggestion-row .rag-score { font-size: 0.85em; opacity: 0.7; margin-left: 4px; }
-        .rag-suggestion-row .rag-actions { display: none; gap: 4px; }
-        .rag-suggestion-row:hover .rag-actions { display: flex; }
-        .rag-suggestion-row .rag-actions button { font-size: 0.8em; padding: 1px 6px; }
+        .rag-suggestions-headline { font-size: 0.9em; font-weight: bold; margin: 4px 4px 2px; opacity: 0.8; }
+        .rag-suggestions-table { width: 100%; border-collapse: collapse; }
+        .rag-suggestion-row td { padding: 2px 4px; vertical-align: middle; }
+        .rag-path-cell { width: 100%; }
+        .rag-path-inner { display: flex; align-items: center; gap: 4px; }
+        .rag-path-label { cursor: pointer; flex: 1; }
+        .rag-path-label:hover { text-decoration: underline; }
+        .rag-score { font-size: 0.85em; opacity: 0.7; white-space: nowrap; }
+        .rag-actions-cell { white-space: nowrap; }
+        .rag-actions { visibility: hidden; display: flex; gap: 4px; align-items: center; }
+        .rag-suggestion-row:hover .rag-actions { visibility: visible; }
+        .rag-actions button { font-size: 0.8em; padding: 1px 6px; }
     `;
     (doc.head || doc.documentElement).appendChild(style);
 }
@@ -101,36 +107,68 @@ function _buildCollectionPath(backendLibraryId, collectionKey, fallbackName) {
 }
 
 /**
- * Build a single suggestion row element.
+ * Navigate the Zotero UI to the specified collection in the collections tree.
+ *
+ * @param {string} backendLibraryId
+ * @param {string} collectionKey
+ * @returns {Promise<void>}
+ */
+async function _selectCollection(backendLibraryId, collectionKey) {
+    const zoteroLibraryID = _resolveZoteroLibraryID(backendLibraryId);
+    if (zoteroLibraryID === null) return;
+    const col = Zotero.Collections.getByLibraryAndKey(zoteroLibraryID, collectionKey);
+    if (!col) return;
+    const zp = Zotero.getActiveZoteroPane();
+    const cv = zp && zp.collectionsView;
+    if (cv && cv.selectCollection) {
+        await cv.selectCollection(col.id);
+    }
+}
+
+/**
+ * Build a single suggestion row as a table row element.
  *
  * @param {import('../api/collections.js').CollectionSuggestion} suggestion
  * @param {any} item - Zotero item
  * @param {Document} doc
- * @returns {HTMLElement}
+ * @returns {HTMLTableRowElement}
  */
 function _buildSuggestionRow(suggestion, item, doc) {
-    const row = /** @type {HTMLElement} */ (doc.createElement("div"));
+    const row = /** @type {HTMLTableRowElement} */ (doc.createElement("tr"));
     row.className = "rag-suggestion-row";
     row.dataset.collectionKey = suggestion.collection_id;
 
-    const box = doc.createElement("div");
-    box.className = "box";
+    // --- Path cell ---
+    const pathCell = doc.createElement("td");
+    pathCell.className = "rag-path-cell";
+
+    const pathInner = doc.createElement("div");
+    pathInner.className = "rag-path-inner";
 
     const icon = doc.createElement("span");
     icon.className = "icon icon-css icon-collection";
 
     const label = doc.createElement("span");
-    label.className = "label";
+    label.className = "rag-path-label";
     label.textContent = _buildCollectionPath(suggestion.library_id, suggestion.collection_id, suggestion.collection_name);
+    label.title = label.textContent;
+    label.addEventListener("click", () => _selectCollection(suggestion.library_id, suggestion.collection_id));
 
     const score = doc.createElement("span");
     score.className = "rag-score";
     score.textContent = `${Math.round(suggestion.score * 100)}%`;
 
-    box.append(icon, label, score);
+    pathInner.append(icon, label, score);
+    pathCell.appendChild(pathInner);
+
+    // --- Actions cell ---
+    const actionsCell = doc.createElement("td");
+    actionsCell.className = "rag-actions-cell";
 
     const actions = doc.createElement("div");
     actions.className = "rag-actions";
+
+    const isSameLibrary = _resolveZoteroLibraryID(suggestion.library_id) === item.libraryID;
 
     const copyBtn = doc.createElement("button");
     copyBtn.textContent = "Copy";
@@ -145,9 +183,16 @@ function _buildSuggestionRow(suggestion, item, doc) {
         await _moveItemToCollection(item, suggestion.library_id, suggestion.collection_id);
         row.remove();
     };
+    // Move across libraries is not possible (foreign-key constraint);
+    // use visibility:hidden so the cell always reserves the same width
+    if (!isSameLibrary) {
+        moveBtn.style.visibility = "hidden";
+        moveBtn.style.pointerEvents = "none";
+    }
 
     actions.append(copyBtn, moveBtn);
-    row.append(box, actions);
+    actionsCell.appendChild(actions);
+    row.append(pathCell, actionsCell);
     return row;
 }
 
@@ -164,8 +209,15 @@ async function _copyItemToCollection(item, backendLibraryId, collectionKey) {
     if (zoteroLibraryID === null) return;
     const col = Zotero.Collections.getByLibraryAndKey(zoteroLibraryID, collectionKey);
     if (!col) return;
-    item.addToCollection(col.id);
-    await item.saveTx();
+    if (item.libraryID === zoteroLibraryID) {
+        item.addToCollection(col.id);
+        await item.saveTx();
+    } else {
+        // Cross-library: clone the item's metadata into the target library
+        const newItem = item.clone(zoteroLibraryID);
+        newItem.addToCollection(col.id);
+        await newItem.saveTx();
+    }
 }
 
 /**
@@ -268,17 +320,39 @@ function registerFilingSuggestionsPane() {
             // Inject styles once per document (idempotent)
             _injectStyles(doc);
 
-            if (!suggestions.length) {
+            // Filter out collections the item is already in (same-library only)
+            const itemBackendLibraryId = _getBackendLibraryId(item);
+            const currentCollectionKeys = new Set(
+                item.getCollections()
+                    .map((/** @type {number} */ id) => Zotero.Collections.get(id)?.key)
+                    .filter(/** @param {string|undefined} k */ k => !!k)
+            );
+            const filteredSuggestions = suggestions.filter(
+                (/** @type {any} */ s) =>
+                    s.library_id !== itemBackendLibraryId || !currentCollectionKeys.has(s.collection_id)
+            );
+
+            if (!filteredSuggestions.length) {
                 const empty = doc.createElement("div");
                 empty.className = "rag-suggestions-empty";
-                empty.setAttribute("data-l10n-id", "pane-filing-suggestions-empty");
+                empty.textContent = "No suggestions yet. Index this item first.";
                 body.appendChild(empty);
                 return;
             }
 
-            for (const suggestion of suggestions) {
-                body.appendChild(_buildSuggestionRow(suggestion, item, doc));
+            const headline = doc.createElement("div");
+            headline.className = "rag-suggestions-headline";
+            headline.textContent = "Suggested collections";
+            body.appendChild(headline);
+
+            const table = doc.createElement("table");
+            table.className = "rag-suggestions-table";
+            const tbody = doc.createElement("tbody");
+            for (const suggestion of filteredSuggestions) {
+                tbody.appendChild(_buildSuggestionRow(suggestion, item, doc));
             }
+            table.appendChild(tbody);
+            body.appendChild(table);
         },
     });
     console.log("[FilingSuggestions] registerSection result:", result); // DEBUG

--- a/plugin/src/ui/item_navigation.js
+++ b/plugin/src/ui/item_navigation.js
@@ -1,0 +1,238 @@
+// @ts-check
+
+/**
+ * Item navigation history for Zotero RAG.
+ *
+ * Injects Back / Forward buttons into the item pane as a persistent footer toolbar.
+ * Tracks item selection history so the user can return to a previously viewed item
+ * after clicking a collection link in the Filing Suggestions pane (or anywhere else).
+ *
+ * This module is self-contained and independent of the rest of the plugin.
+ * It registers a permanently-hidden section solely to receive the onItemChange callback.
+ * The nav bar is injected into each main window via the onInit hook.
+ *
+ * Manual verification:
+ * - "← Back" and "→ Forward" footer buttons appear at the bottom of the item pane
+ * - Both buttons are disabled initially (no history)
+ * - Selecting a new item enables Back; Forward remains disabled
+ * - Clicking Back navigates to the previous item; Forward is now enabled
+ * - Clicking a collection path in Filing Suggestions selects that collection;
+ *   pressing Back restores the item view with the Filing Suggestions pane intact
+ */
+
+var _NAV_PANE_ID = "zotero-rag-item-navigation";
+var _NAV_PLUGIN_ID = "zotero-rag@cboulanger.github.io";
+
+/** @type {number[]} Item ID history stack */
+var _navHistory = [];
+/** @type {number} Cursor into _navHistory; -1 = empty */
+var _navCursor = -1;
+/**
+ * Suppresses history recording for the single onItemChange that fires
+ * in response to our own Back/Forward navigation.
+ * @type {number|null}
+ */
+var _navExpectedItemId = null;
+
+// ---------------------------------------------------------------------------
+// History management
+// ---------------------------------------------------------------------------
+
+/**
+ * Record an item-change event.  Called from the hidden section's onItemChange hook.
+ *
+ * @param {any} item - Zotero item (may be null when pane is empty)
+ */
+function _navRecordItem(item) {
+    if (!item || !item.id) {
+        _navUpdateAllButtons();
+        return;
+    }
+
+    // If this change is the result of our own navigation, skip it.
+    if (_navExpectedItemId !== null && _navExpectedItemId === item.id) {
+        _navExpectedItemId = null;
+        _navUpdateAllButtons();
+        return;
+    }
+    _navExpectedItemId = null;
+
+    // Truncate any forward history and push the new item.
+    _navHistory = _navHistory.slice(0, _navCursor + 1);
+    if (_navHistory.length === 0 || _navHistory[_navCursor] !== item.id) {
+        _navHistory.push(item.id);
+        _navCursor = _navHistory.length - 1;
+    }
+
+    _navUpdateAllButtons();
+}
+
+/**
+ * Refresh enabled state of Back/Forward buttons in every open main window.
+ */
+function _navUpdateAllButtons() {
+    const canBack = _navCursor > 0;
+    const canFwd = _navCursor < _navHistory.length - 1;
+    for (const win of Zotero.getMainWindows()) {
+        const back = win.document.getElementById("rag-nav-back");
+        const fwd = win.document.getElementById("rag-nav-forward");
+        if (back) back.disabled = !canBack;
+        if (fwd) fwd.disabled = !canFwd;
+    }
+}
+
+/**
+ * Navigate backwards through item history.
+ * @returns {Promise<void>}
+ */
+async function _navGoBack() {
+    if (_navCursor <= 0) return;
+    _navCursor--;
+    _navExpectedItemId = _navHistory[_navCursor];
+    const zp = Zotero.getActiveZoteroPane();
+    if (zp) await zp.selectItem(_navHistory[_navCursor], { inLibraryRoot: true });
+    _navUpdateAllButtons();
+}
+
+/**
+ * Navigate forwards through item history.
+ * @returns {Promise<void>}
+ */
+async function _navGoForward() {
+    if (_navCursor >= _navHistory.length - 1) return;
+    _navCursor++;
+    _navExpectedItemId = _navHistory[_navCursor];
+    const zp = Zotero.getActiveZoteroPane();
+    if (zp) await zp.selectItem(_navHistory[_navCursor], { inLibraryRoot: true });
+    _navUpdateAllButtons();
+}
+
+// ---------------------------------------------------------------------------
+// DOM injection
+// ---------------------------------------------------------------------------
+
+/**
+ * Inject the navigation footer into the item pane of the given document.
+ * Idempotent: does nothing if the bar is already present.
+ *
+ * The bar is inserted after #zotero-view-item (the scrollable sections container)
+ * inside .zotero-view-item-main, which is a flex column.  The bar therefore
+ * appears as a fixed-height footer below the scrollable content.
+ *
+ * @param {Document} doc
+ */
+function _navInjectBar(doc) {
+    if (doc.getElementById("rag-nav-bar")) return;
+
+    const viewItem = doc.getElementById("zotero-view-item");
+    if (!viewItem) return;
+
+    // Styles — injected once per document
+    if (!doc.getElementById("rag-nav-style")) {
+        const style = doc.createElement("style");
+        style.id = "rag-nav-style";
+        style.textContent = `
+            #rag-nav-bar {
+                display: flex;
+                gap: 4px;
+                padding: 3px 6px;
+                border-top: 1px solid var(--material-border, #c8c8c8);
+                background: var(--material-sidepane, transparent);
+                flex-shrink: 0;
+            }
+            #rag-nav-bar button {
+                font-size: 0.8em;
+                padding: 1px 10px;
+                min-width: 60px;
+            }
+        `;
+        (doc.head || doc.documentElement).appendChild(style);
+    }
+
+    const bar = doc.createElement("div");
+    bar.id = "rag-nav-bar";
+
+    const backBtn = doc.createElement("button");
+    backBtn.id = "rag-nav-back";
+    backBtn.textContent = "← Back";
+    backBtn.title = "Go to the previously viewed item";
+    backBtn.disabled = true;
+    backBtn.onclick = () => _navGoBack();
+
+    const fwdBtn = doc.createElement("button");
+    fwdBtn.id = "rag-nav-forward";
+    fwdBtn.textContent = "Forward →";
+    fwdBtn.title = "Go to the next item in history";
+    fwdBtn.disabled = true;
+    fwdBtn.onclick = () => _navGoForward();
+
+    bar.append(backBtn, fwdBtn);
+    // Insert as footer: after the scrollable content, inside the flex column
+    viewItem.insertAdjacentElement("afterend", bar);
+}
+
+/**
+ * Remove the navigation footer from the given document.
+ * @param {Document} doc
+ */
+function _navRemoveBar(doc) {
+    doc.getElementById("rag-nav-bar")?.remove();
+    doc.getElementById("rag-nav-style")?.remove();
+}
+
+// ---------------------------------------------------------------------------
+// Section registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the item navigation helper.
+ * Registers a permanently-hidden section to receive onItemChange events,
+ * and injects the nav bar into each window via onInit.
+ *
+ * Called from bootstrap.js after startup completes.
+ */
+function registerItemNavigation() {
+    Zotero.ItemPaneManager.registerSection({
+        paneID: _NAV_PANE_ID,
+        pluginID: _NAV_PLUGIN_ID,
+        header: {
+            // Section is always hidden; the l10n key and icon are required by the API
+            // but never displayed.
+            l10nID: "pane-item-navigation",
+            icon: "chrome://zotero/skin/16/universal/restore.svg",
+        },
+        sidenav: {
+            l10nID: "pane-item-navigation",
+            icon: "chrome://zotero/skin/20/universal/sync.svg",
+        },
+
+        onInit: ({ doc }) => {
+            _navInjectBar(doc);
+        },
+
+        onDestroy: ({ doc }) => {
+            _navRemoveBar(doc);
+        },
+
+        /**
+         * @param {{ item: any, setEnabled: (enabled: boolean) => void }} param0
+         */
+        onItemChange: ({ item, setEnabled }) => {
+            setEnabled(false); // Keep the section itself hidden — we only need the callback
+            _navRecordItem(item);
+        },
+
+        // onRender is required by the API; no-op since we have no visible body.
+        onRender: () => {},
+    });
+}
+
+/**
+ * Unregister the item navigation helper.
+ * Nav bars are cleaned up via the onDestroy callback.
+ *
+ * Called from bootstrap.js during shutdown.
+ */
+function unregisterItemNavigation() {
+    Zotero.ItemPaneManager.unregisterSection(_NAV_PANE_ID);
+}

--- a/plugin/test/api_collections.test.js
+++ b/plugin/test/api_collections.test.js
@@ -1,0 +1,385 @@
+'use strict';
+
+/**
+ * Tests for plugin/src/api/collections.js
+ *
+ * Uses Node.js built-in test runner. Run with: node --test plugin/test/api_collections.test.js
+ *
+ * The collections.js module is loaded via vm to simulate the non-module Zotero plugin environment
+ * (no import/export). We stub globalThis.fetch before each test.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// ---------------------------------------------------------------------------
+// Load the module into a shared context that mirrors the plugin environment.
+// The file uses no import/export — CollectionsAPI is declared at module scope.
+//
+// Note: `const` declarations in a vm context are NOT enumerable on the sandbox
+// object. We wrap the source so that the CollectionsAPI const is also assigned
+// to `sandbox._CollectionsAPI` which IS accessible on the sandbox.
+// ---------------------------------------------------------------------------
+
+const moduleSrc = fs.readFileSync(
+    path.join(__dirname, '../src/api/collections.js'),
+    'utf8'
+);
+
+// Append an assignment that exposes CollectionsAPI on the context object.
+const wrappedSrc = moduleSrc + '\n_CollectionsAPI = CollectionsAPI;\n';
+
+/**
+ * Create a fresh sandbox and evaluate the module source in it.
+ * Returns an object with a `CollectionsAPI` property and a `fetch` property
+ * that tests can override to mock HTTP requests.
+ *
+ * @returns {{ CollectionsAPI: object, fetch: Function }}
+ */
+function loadModule() {
+    /** @type {any} */
+    const sandbox = {
+        // The module calls `fetch(...)` — we expose it as a property so tests
+        // can swap it per-test. We initially set it to a no-op so the sandbox
+        // context is valid even before tests set their mock.
+        fetch: async () => { throw new Error('fetch not mocked'); },
+        // Placeholder that the wrapped source writes into.
+        _CollectionsAPI: null,
+        // Make AbortSignal available (used in syncCollectionVectors tests).
+        AbortSignal,
+        // Expose console so any accidental logs don't crash.
+        console,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(wrappedSrc, sandbox);
+    sandbox.CollectionsAPI = sandbox._CollectionsAPI;
+    return sandbox;
+}
+
+// ---------------------------------------------------------------------------
+// Helper to build a minimal mock Response object.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {number} status
+ * @param {unknown} body - Will be JSON-serialised.
+ * @param {Record<string,string>} [extraHeaders]
+ * @returns {Response}
+ */
+function mockJsonResponse(status, body, extraHeaders = {}) {
+    const jsonText = JSON.stringify(body);
+    return /** @type {Response} */ ({
+        ok: status >= 200 && status < 300,
+        status,
+        headers: {
+            get(name) {
+                const lower = name.toLowerCase();
+                if (lower === 'content-type') return 'application/json';
+                return extraHeaders[lower] || null;
+            },
+        },
+        async json() { return JSON.parse(jsonText); },
+        async text() { return jsonText; },
+    });
+}
+
+/**
+ * @param {number} status
+ * @param {string} text
+ * @returns {Response}
+ */
+function mockTextResponse(status, text) {
+    return /** @type {Response} */ ({
+        ok: status >= 200 && status < 300,
+        status,
+        headers: {
+            get(name) {
+                if (name.toLowerCase() === 'content-type') return 'text/plain';
+                return null;
+            },
+        },
+        async json() { throw new Error('not json'); },
+        async text() { return text; },
+    });
+}
+
+/** @returns {Record<string,string>} */
+function getAuthHeaders() {
+    return { Authorization: 'Bearer test-token' };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CollectionsAPI', () => {
+    /** @type {any} */
+    let CollectionsAPI;
+    /** @type {ReturnType<typeof loadModule>} */
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = loadModule();
+        CollectionsAPI = sandbox.CollectionsAPI;
+    });
+
+    afterEach(() => {
+        // Restore any fetch mock on globalThis (loadModule uses sandbox.fetch, not globalThis.fetch directly,
+        // but we patch globalThis.fetch before each loadModule call in some tests so clean up here).
+        delete globalThis.fetch;
+    });
+
+    // -----------------------------------------------------------------------
+    // getCollectionVectorsStatus
+    // -----------------------------------------------------------------------
+
+    describe('getCollectionVectorsStatus', () => {
+        test('returns parsed status object on 200', async () => {
+            /** @type {CollectionVectorsStatus} */
+            const expected = {
+                library_id: 'lib1',
+                item_vectors_count: 42,
+                collection_vectors_count: 7,
+                computed: true,
+            };
+
+            sandbox.fetch = async (url, init) => {
+                assert.ok(url.includes('/api/collections/vectors/status'));
+                assert.ok(url.includes('library_id=lib1'));
+                assert.equal(init.method, 'GET');
+                return mockJsonResponse(200, expected);
+            };
+
+            const result = await CollectionsAPI.getCollectionVectorsStatus(
+                'http://localhost:8000',
+                'lib1',
+                getAuthHeaders
+            );
+
+            // Cross-realm object comparison via JSON to avoid deepStrictEqual prototype issues.
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+
+        test('throws on HTTP error (e.g. 500)', async () => {
+            sandbox.fetch = async () => mockTextResponse(500, 'Internal Server Error');
+
+            await assert.rejects(
+                () => CollectionsAPI.getCollectionVectorsStatus('http://localhost:8000', 'lib1', getAuthHeaders),
+                (err) => {
+                    // err is thrown from the vm context — instanceof Error is cross-realm and fails.
+                    assert.ok(err && typeof err.message === 'string', 'expected an Error-like object');
+                    assert.ok(err.message.includes('500'));
+                    return true;
+                }
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // syncCollectionVectors
+    // -----------------------------------------------------------------------
+
+    describe('syncCollectionVectors', () => {
+        test('sends correct body and returns stats on 200', async () => {
+            /** @type {SyncCollectionVectorsResult} */
+            const expected = {
+                items_computed: 10,
+                items_skipped: 2,
+                collections_computed: 3,
+                collections_skipped: 1,
+            };
+
+            /** @type {string|undefined} */
+            let capturedUrl;
+            /** @type {RequestInit|undefined} */
+            let capturedInit;
+
+            sandbox.fetch = async (url, init) => {
+                capturedUrl = url;
+                capturedInit = init;
+                return mockJsonResponse(200, expected);
+            };
+
+            /** @type {Object.<string, string[]>} */
+            const collectionMap = { ABCD1234: ['col1', 'col2'], EFGH5678: ['col3'] };
+            /** @type {Object.<string, string>} */
+            const collectionNames = { col1: 'Physics', col2: 'Chemistry', col3: 'Biology' };
+
+            const result = await CollectionsAPI.syncCollectionVectors(
+                'http://localhost:8000',
+                'lib1',
+                collectionMap,
+                collectionNames,
+                getAuthHeaders
+            );
+
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+            assert.ok(capturedUrl.includes('/api/collections/vectors/sync'));
+            assert.equal(capturedInit.method, 'POST');
+
+            const sentBody = JSON.parse(capturedInit.body);
+            assert.equal(JSON.stringify(sentBody), JSON.stringify({
+                library_id: 'lib1',
+                collection_map: collectionMap,
+                collection_names: collectionNames,
+            }));
+        });
+
+        test('forwards AbortSignal to fetch', async () => {
+            sandbox.fetch = async (url, init) => {
+                assert.ok(init.signal instanceof AbortSignal);
+                return mockJsonResponse(200, { items_computed: 0, items_skipped: 0, collections_computed: 0, collections_skipped: 0 });
+            };
+
+            const signal = AbortSignal.timeout(30000);
+            await CollectionsAPI.syncCollectionVectors(
+                'http://localhost:8000',
+                'lib1',
+                {},
+                {},
+                getAuthHeaders,
+                signal
+            );
+        });
+
+        test('throws on HTTP error', async () => {
+            sandbox.fetch = async () => mockJsonResponse(422, { detail: 'Validation error' });
+
+            await assert.rejects(
+                () => CollectionsAPI.syncCollectionVectors(
+                    'http://localhost:8000', 'lib1', {}, {}, getAuthHeaders
+                ),
+                (err) => {
+                    assert.ok(err && typeof err.message === 'string', 'expected an Error-like object');
+                    assert.ok(err.message.includes('422'));
+                    return true;
+                }
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // suggestCollections
+    // -----------------------------------------------------------------------
+
+    describe('suggestCollections', () => {
+        test('returns suggestions array on 200', async () => {
+            /** @type {Array<CollectionSuggestion>} */
+            const expected = [
+                { collection_id: 'col1', collection_name: 'Physics', library_id: 'lib1', score: 0.92 },
+                { collection_id: 'col2', collection_name: 'Chemistry', library_id: 'lib1', score: 0.87 },
+            ];
+
+            sandbox.fetch = async (url, init) => {
+                assert.ok(url.includes('/api/collections/suggest'));
+                assert.ok(url.includes('library_id=lib1'));
+                assert.ok(url.includes('item_key=ABCD1234'));
+                assert.ok(url.includes('limit=5'));
+                return mockJsonResponse(200, expected);
+            };
+
+            const result = await CollectionsAPI.suggestCollections(
+                'http://localhost:8000',
+                'lib1',
+                'ABCD1234',
+                getAuthHeaders
+            );
+
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+
+        test('returns [] on 404 (item vector not yet computed)', async () => {
+            sandbox.fetch = async () => mockJsonResponse(404, { detail: 'Item not found' });
+
+            const result = await CollectionsAPI.suggestCollections(
+                'http://localhost:8000',
+                'lib1',
+                'MISSING_KEY',
+                getAuthHeaders
+            );
+
+            // The array is from the vm context so deepStrictEqual fails on cross-realm array.
+            // Use length check and JSON comparison instead.
+            assert.equal(result.length, 0, 'expected empty array on 404');
+        });
+
+        test('throws on 500 error', async () => {
+            sandbox.fetch = async () => mockTextResponse(500, 'Internal Server Error');
+
+            await assert.rejects(
+                () => CollectionsAPI.suggestCollections(
+                    'http://localhost:8000', 'lib1', 'ABCD1234', getAuthHeaders
+                ),
+                (err) => {
+                    assert.ok(err && typeof err.message === 'string', 'expected an Error-like object');
+                    assert.ok(err.message.includes('500'));
+                    return true;
+                }
+            );
+        });
+
+        test('throws on 401 error', async () => {
+            sandbox.fetch = async () => mockJsonResponse(401, { detail: 'Unauthorized' });
+
+            await assert.rejects(
+                () => CollectionsAPI.suggestCollections(
+                    'http://localhost:8000', 'lib1', 'ABCD1234', getAuthHeaders
+                ),
+                (err) => {
+                    assert.ok(err && typeof err.message === 'string', 'expected an Error-like object');
+                    assert.ok(err.message.includes('401'));
+                    return true;
+                }
+            );
+        });
+
+        test('uses default limit of 5 when not specified', async () => {
+            sandbox.fetch = async (url) => {
+                assert.ok(url.includes('limit=5'), `Expected limit=5 in URL, got: ${url}`);
+                return mockJsonResponse(200, []);
+            };
+
+            await CollectionsAPI.suggestCollections(
+                'http://localhost:8000', 'lib1', 'ABCD1234', getAuthHeaders
+            );
+        });
+
+        test('uses custom limit when specified', async () => {
+            sandbox.fetch = async (url) => {
+                assert.ok(url.includes('limit=10'), `Expected limit=10 in URL, got: ${url}`);
+                return mockJsonResponse(200, []);
+            };
+
+            await CollectionsAPI.suggestCollections(
+                'http://localhost:8000', 'lib1', 'ABCD1234', getAuthHeaders, 10
+            );
+        });
+    });
+});
+
+/**
+ * @typedef {Object} CollectionVectorsStatus
+ * @property {string} library_id
+ * @property {number} item_vectors_count
+ * @property {number} collection_vectors_count
+ * @property {boolean} computed
+ */
+
+/**
+ * @typedef {Object} SyncCollectionVectorsResult
+ * @property {number} items_computed
+ * @property {number} items_skipped
+ * @property {number} collections_computed
+ * @property {number} collections_skipped
+ */
+
+/**
+ * @typedef {Object} CollectionSuggestion
+ * @property {string} collection_id
+ * @property {string} collection_name
+ * @property {string} library_id
+ * @property {number} score
+ */

--- a/plugin/test/api_collections.test.js
+++ b/plugin/test/api_collections.test.js
@@ -291,8 +291,8 @@ describe('CollectionsAPI', () => {
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
 
-        test('returns [] on 404 (item vector not yet computed)', async () => {
-            sandbox.fetch = async () => mockJsonResponse(404, { detail: 'Item not found' });
+        test('returns [] when no item vector exists (backend returns 200 + empty array)', async () => {
+            sandbox.fetch = async () => mockJsonResponse(200, []);
 
             const result = await CollectionsAPI.suggestCollections(
                 'http://localhost:8000',
@@ -301,9 +301,7 @@ describe('CollectionsAPI', () => {
                 getAuthHeaders
             );
 
-            // The array is from the vm context so deepStrictEqual fails on cross-realm array.
-            // Use length check and JSON comparison instead.
-            assert.equal(result.length, 0, 'expected empty array on 404');
+            assert.equal(result.length, 0, 'expected empty array when no vector exists');
         });
 
         test('throws on 500 error', async () => {

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -5,4 +5,6 @@
 export type FluentMessageId =
   | 'pane-filing-suggestions'
   | 'pane-filing-suggestions-empty'
+  | 'pane-filing-suggestions-title'
+  | 'pane-item-navigation'
   | 'zotero-rag-ask-question';

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -3,4 +3,6 @@
 /* eslint-disable */
 // @ts-nocheck
 export type FluentMessageId =
+  | 'pane-filing-suggestions'
+  | 'pane-filing-suggestions-empty'
   | 'zotero-rag-ask-question';


### PR DESCRIPTION
## Summary

- Adds two new Qdrant collections (`item_vectors`, `collection_vectors`) that store per-item title+abstract embeddings and per-collection centroid vectors; both are auto-created on backend startup with no migration required
- Adds three new API endpoints (`GET /api/collections/vectors/status`, `POST /api/collections/vectors/sync`, `GET /api/collections/suggest`) and a `CollectionVectorService` that computes item vectors (A2: title+abstract, falling back to A1: mean-pool chunk vectors) and collection centroids
- Adds a "Filing Suggestions" section to the Zotero item pane (via `ItemPaneManager.registerSection`) showing ranked collection suggestions with hover **Copy** / **Move** actions; stage 7 of the indexing pipeline syncs collection vectors after indexing completes (non-blocking)

## Architecture notes

- Item vectors use a deterministic UUID5 key for idempotent upserts
- Stage 7 is wrapped in `try/catch` and does not block or affect the "Indexed" status displayed to the user
- A `TODO` marks the future incremental path (`item_vector_pending` flag → per-item update endpoint) that will make syncs O(new items) instead of O(library size)

## Test Plan

- [ ] `uv run pytest` — 312 passed, 2 skipped
- [ ] `node --test plugin/test/api_collections.test.js` — 11 passed
- [ ] Start dev server (`npm run start`), index a library with well-categorised collections
- [ ] Confirm `GET /api/collections/vectors/status` returns `{"computed": true}`
- [ ] Open a newly indexed item → "Filing Suggestions" pane visible in item pane
- [ ] Hover over a suggestion → Copy and Move buttons appear
- [ ] Click Copy → item added to target collection, suggestion removed from list
- [ ] Click Move → item removed from current collections and added to target

🤖 Generated with [Claude Code](https://claude.com/claude-code)