### PR TITLE
Zotero-key authentication: per-user identity, access gate, plugin wizard

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -68,13 +68,6 @@ LOG_LEVEL=INFO
 # team without a dedicated Zotero group.
 # AUTHORIZED_USER_IDS=39226,123456
 
-# Legacy shared secret, kept only for the transitional migration window while
-# users upgrade to a plugin version that sends X-Zotero-API-Key. A request
-# presenting this key bypasses per-library authorization entirely (the same
-# way ALL requests did before this feature) — do not treat it as a
-# long-term deployment mode for a multi-user instance.
-# API_KEY=your_shared_secret
-
 # Document extraction backend.
 #   kreuzberg (default) — supports 91+ formats, OCR, DOCX, EPUB, etc.
 #                         Requires Docker or Podman to run the kreuzberg sidecar.

--- a/.env.dist
+++ b/.env.dist
@@ -52,6 +52,38 @@ LOG_LEVEL=INFO
 # Default: true
 # REQUIRE_REGISTRATION=true
 
+# =============================================================================
+# Access Control (Zotero-key authentication)
+# =============================================================================
+
+# Loopback deployments (API_HOST unset or localhost/127.0.0.1) need none of
+# this: there is exactly one trusted local user and no Zotero-key auth is
+# required at all.
+#
+# Every other deployment authenticates each request with the caller's own
+# read-only Zotero API key (sent by the plugin as X-Zotero-API-Key) and then
+# checks it against an access gate below — a valid Zotero key alone is NOT
+# enough, since any Zotero.org account could otherwise use your server.
+# At least one of AUTHORIZED_GROUP_ID / AUTHORIZED_USER_IDS is REQUIRED for a
+# non-loopback deployment; the server refuses to start without one.
+
+# Zotero group ID that gates access. A caller is authorized if their key
+# grants read access to this group (i.e. they are a member of it). Manage
+# membership entirely on zotero.org — no redeploy needed to add/remove users.
+# AUTHORIZED_GROUP_ID=998877
+
+# Explicit allowlist of Zotero user IDs, in addition to AUTHORIZED_GROUP_ID
+# (OR semantics). Comma-separated. Useful as a fallback or for a small fixed
+# team without a dedicated Zotero group.
+# AUTHORIZED_USER_IDS=39226,123456
+
+# Legacy shared secret, kept only for the transitional migration window while
+# users upgrade to a plugin version that sends X-Zotero-API-Key. A request
+# presenting this key bypasses per-library authorization entirely (the same
+# way ALL requests did before this feature) — do not treat it as a
+# long-term deployment mode for a multi-user instance.
+# API_KEY=your_shared_secret
+
 # Document extraction backend.
 #   kreuzberg (default) — supports 91+ formats, OCR, DOCX, EPUB, etc.
 #                         Requires Docker or Podman to run the kreuzberg sidecar.

--- a/.env.dist
+++ b/.env.dist
@@ -44,15 +44,6 @@ MODEL_PRESET=remote-kisski
 LOG_LEVEL=INFO
 
 # =============================================================================
-# Registration
-# =============================================================================
-
-# Require users to register before indexing documents.
-# Automatically skipped for localhost deployments (api_host=localhost/127.0.0.1).
-# Default: true
-# REQUIRE_REGISTRATION=true
-
-# =============================================================================
 # Access Control (Zotero-key authentication)
 # =============================================================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,11 +117,7 @@ The hourly cron job is defined in `/etc/cron.d/zotero-rag-indexer`. It runs `ind
 
 **Key flow — auto-index keys (not `--slugs-file` / `ZOTERO_API_KEY`):**
 
-The cron job no longer uses a static slugs file or a global `ZOTERO_API_KEY`. Instead, indexing targets come from the encrypted auto-index key store at `<data_path>/system/autoindex_keys.json`. Keys are added by users via the plugin (Preferences → Automatic indexing) or on the server with:
-
-As of the zotero-key-auth migration, the same personal Zotero API key a user enters in the
-plugin's setup wizard (or Preferences) also authenticates their normal plugin use — auto-indexing
-is just an on/off toggle reusing that key, not a separate credential.
+The cron job no longer uses a static slugs file or a global `ZOTERO_API_KEY`. Instead, indexing targets come from the encrypted auto-index key store at `<data_path>/system/autoindex_keys.json`. The same personal Zotero API key a user enters in the plugin's setup wizard (or Preferences) also authenticates their normal plugin use — auto-indexing is just an on/off toggle reusing that key, not a separate credential. Keys are added by users via the plugin (Preferences → Automatic indexing) or on the server with:
 
 ```bash
 uv run python bin/autoindex_add_key.py <read-only-zotero-api-key>
@@ -372,6 +368,7 @@ For creating dialog windows in Zotero plugins:
 - Keep inline comments focused on "why" rather than "what"
 - In Javascript files, use TypeScript-compatible JSDOC annotations throughout for typing variables and documenting function parameters. Use the full power or typescript embedded in JSDoc, don't use generic types. Remember this is plain javascript, don't use Typescript directly.
 - **Never fix markdown lint issues (formatting, table style, etc.) in files under `docs/history/`** (including `docs/history/implementation/`). These are historical/implementation-progress records written for agent consumption when resuming work, not published documentation — don't spend edits polishing their formatting.
+- **User-facing documentation (README, CLAUDE.md's operational sections, `docs/*.md` architecture/setup guides, `.env.dist` comments, plugin UI/help text) must describe only the current status-quo behavior — do not reference prior behavior a feature migrated from ("previously X, now Y", "as of the Z migration", etc.).** The software is not yet publicly released, so there is no installed base that needs migration context; mentioning a superseded behavior only confuses a reader who never saw it. This rule applies for any `1.*` release; it no longer applies once the project reaches `2.0` or later (at that point documenting migrations for upgrading users becomes appropriate). This does **not** apply to `docs/history/` and `docs/superpowers/` records, which are explicitly historical/planning documents for agent consumption, not user-facing docs.
 
 ## Implementation progress documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,10 @@ The hourly cron job is defined in `/etc/cron.d/zotero-rag-indexer`. It runs `ind
 
 The cron job no longer uses a static slugs file or a global `ZOTERO_API_KEY`. Instead, indexing targets come from the encrypted auto-index key store at `<data_path>/system/autoindex_keys.json`. Keys are added by users via the plugin (Preferences → Automatic indexing) or on the server with:
 
+As of the zotero-key-auth migration, the same personal Zotero API key a user enters in the
+plugin's setup wizard (or Preferences) also authenticates their normal plugin use — auto-indexing
+is just an on/off toggle reusing that key, not a separate credential.
+
 ```bash
 uv run python bin/autoindex_add_key.py <read-only-zotero-api-key>
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,7 @@ For creating dialog windows in Zotero plugins:
 - Document configuration options and environment variables
 - Keep inline comments focused on "why" rather than "what"
 - In Javascript files, use TypeScript-compatible JSDOC annotations throughout for typing variables and documenting function parameters. Use the full power or typescript embedded in JSDoc, don't use generic types. Remember this is plain javascript, don't use Typescript directly.
+- **Never fix markdown lint issues (formatting, table style, etc.) in files under `docs/history/`** (including `docs/history/implementation/`). These are historical/implementation-progress records written for agent consumption when resuming work, not published documentation — don't spend edits polishing their formatting.
 
 ## Implementation progress documentation
 

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,0 +1,31 @@
+"""Identity-check endpoint used by the plugin's Preferences pane and setup
+wizard to validate a Zotero API key before/without saving it, and to show
+the caller which libraries their key can access.
+
+Deliberately thin: all the validation, caching, and gate logic already runs
+in the auth middleware (backend.dependencies.resolve_zotero_identity) for
+every /api/* request. This handler only reads back the result — a 401/403/503
+never reaches it, the middleware already returned that response.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+
+from backend.dependencies import get_zotero_identity
+from backend.services.zotero_identity import ZoteroIdentity
+
+router = APIRouter()
+
+
+@router.get("/auth/whoami", summary="Validate the caller's Zotero API key and return their identity")
+def whoami(identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity)) -> dict:
+    if identity is None:
+        return {"authorized": True, "loopback": True}
+    return {
+        "authorized": True,
+        "loopback": False,
+        "user_id": identity.user_id,
+        "username": identity.username,
+        "targets": identity.targets,
+    }

--- a/backend/api/autoindex.py
+++ b/backend/api/autoindex.py
@@ -82,7 +82,7 @@ def list_keys(identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity))
 
 
 @router.get("/autoindex/status", summary="Live auto-index cron-run progress")
-def status() -> dict:
+def status(identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity)) -> dict:
     """Return the live status of the auto-index cron run.
 
     Unlike the ``/`` root endpoint (which exposes only ``enabled``), this
@@ -92,6 +92,14 @@ def status() -> dict:
     When the feature is disabled (``AUTOINDEX_SECRET`` unset) ``keys_registered``
     is ``0`` and ``disabled_reason`` explains why. Run-specific fields are absent
     until the first cron run writes a status file.
+
+    On loopback deployments (identity=None) returns full detail unfiltered,
+    matching the single-trusted-local-user model used throughout this
+    backend's Zotero-key auth. On a gated remote deployment, ``slugs`` is
+    filtered to the caller's own readable targets and ``key_issues`` to
+    entries matching the caller's own username — this endpoint previously
+    leaked every user's real username and every library's slug/stats to any
+    caller who merely passed the instance-wide access gate.
     """
     settings = get_settings()
     result: dict = {}
@@ -113,4 +121,17 @@ def status() -> dict:
         result.update(read_live_status(settings.data_path))
     except Exception as exc:
         logger.warning("Failed to read cron status file: %s", exc)
+
+    if identity is not None:
+        if "slugs" in result:
+            result["slugs"] = {
+                slug: info for slug, info in result["slugs"].items()
+                if slug in identity.targets
+            }
+        if "key_issues" in result:
+            result["key_issues"] = [
+                issue for issue in result["key_issues"]
+                if issue.get("user") == identity.username
+            ]
+
     return result

--- a/backend/api/autoindex.py
+++ b/backend/api/autoindex.py
@@ -2,7 +2,7 @@
 
 POST   /api/autoindex/keys    — submit a read-only key (validated, stored encrypted)
 DELETE /api/autoindex/keys    — remove a key
-GET    /api/autoindex/keys    — list key metadata (admin; no plaintext)
+GET    /api/autoindex/keys    — list the caller's own key metadata (no plaintext)
 GET    /api/autoindex/status  — live cron-run progress (running/crashed, counts)
 
 All endpoints are protected by the global X-API-Key middleware. When
@@ -11,13 +11,16 @@ AUTOINDEX_SECRET is unset the feature is disabled and the key endpoints return 5
 
 import asyncio
 import logging
+from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.config.settings import get_settings
+from backend.dependencies import get_zotero_identity
 from backend.services.autoindex_key_store import AutoIndexKeyStore
 from backend.services.cron_indexer import read_live_status
+from backend.services.zotero_identity import ZoteroIdentity
 from backend.zotero.key_validator import validate_key
 
 router = APIRouter()
@@ -60,10 +63,22 @@ def delete_key(request: KeyRequest) -> dict:
     return {"removed": removed}
 
 
-@router.get("/autoindex/keys", summary="List auto-index key metadata (admin)")
-def list_keys() -> dict:
+@router.get("/autoindex/keys", summary="List the caller's own auto-index key metadata")
+def list_keys(identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity)) -> dict:
+    """List auto-index key metadata.
+
+    On loopback deployments (identity=None) returns every submitted key's
+    metadata unfiltered, matching the single-trusted-local-user model used
+    throughout this backend's Zotero-key auth. On a gated remote deployment,
+    each caller sees only their own submitted key's metadata, not other
+    users' — this endpoint previously leaked every user's real username and
+    user_id to any caller who merely passed the instance-wide access gate.
+    """
     store = _store()
-    return {"keys": store.list_metadata()}
+    all_keys = store.list_metadata()
+    if identity is None:
+        return {"keys": all_keys}
+    return {"keys": [k for k in all_keys if k.get("user_id") == identity.user_id]}
 
 
 @router.get("/autoindex/status", summary="Live auto-index cron-run progress")

--- a/backend/api/autoindex.py
+++ b/backend/api/autoindex.py
@@ -5,7 +5,7 @@ DELETE /api/autoindex/keys    — remove a key
 GET    /api/autoindex/keys    — list the caller's own key metadata (no plaintext)
 GET    /api/autoindex/status  — live cron-run progress (running/crashed, counts)
 
-All endpoints are protected by the global X-API-Key middleware. When
+All endpoints are protected by the global Zotero-key auth middleware (X-Zotero-API-Key). When
 AUTOINDEX_SECRET is unset the feature is disabled and the key endpoints return 503.
 """
 

--- a/backend/api/document_upload.py
+++ b/backend/api/document_upload.py
@@ -439,6 +439,7 @@ async def _run_task(task_id: str, **kwargs: object) -> None:
 async def check_indexed(
     library_id: str,
     request: CheckIndexedRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """
@@ -464,6 +465,8 @@ async def check_indexed(
             status_code=400,
             detail="library_id in URL must match library_id in request body",
         )
+
+    assert_can_access(identity, library_id)
 
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")

--- a/backend/api/document_upload.py
+++ b/backend/api/document_upload.py
@@ -30,15 +30,16 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Uplo
 from pydantic import BaseModel
 
 from backend.db.vector_store import VectorStore, _extract_lastnames
-from backend.dependencies import get_client_api_keys, get_vector_store, make_embedding_service
+from backend.dependencies import get_client_api_keys, get_vector_store, get_zotero_identity, make_embedding_service
 from backend.models.document import (
     CURRENT_SCHEMA_VERSION,
     DocumentMetadata,
 )
 from backend.models.library import LibraryIndexMetadata
+from backend.services.access_gate import assert_can_access
 from backend.services.document_processor import DocumentProcessor
-from backend.services.registration_service import RegistrationService
-from backend.config.settings import Settings, get_settings
+from backend.services.zotero_identity import ZoteroIdentity
+from backend.config.settings import get_settings
 from backend.utils import format_file_size
 
 router = APIRouter()
@@ -236,32 +237,11 @@ class AbstractIndexRequest(BaseModel):
     zotero_modified: str = ""
     abstract_text: str
     library_name: str = ""
-    user_id: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _check_registration(library_id: str, user_id: Optional[int], settings: Settings) -> None:
-    """Raise 403 if registration is required and the user is not registered.
-
-    Skipped when api_host is localhost/127.0.0.1 or REQUIRE_REGISTRATION=false.
-    """
-    if not settings.require_registration:
-        return
-    if settings.api_host in ("localhost", "127.0.0.1"):
-        return
-    service = RegistrationService(settings.registrations_path)
-    if not service.is_registered(library_id, user_id):
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "Library not registered for this user. "
-                "Please update the plugin to the newest version."
-            ),
-        )
 
 
 async def _execute_upload(
@@ -605,6 +585,7 @@ async def upload_and_index_document(
             "zotero_modified (ISO 8601 string)"
         ),
     ),
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """
@@ -634,7 +615,7 @@ async def upload_and_index_document(
     """
     meta_dict, doc_metadata, library_id, item_key, attachment_key, user_id, \
         library_type, mime_type, item_version, attachment_version, item_modified, \
-        file_bytes = await _parse_upload_request(file, metadata)
+        file_bytes = await _parse_upload_request(file, metadata, identity)
 
     logger.info(
         f"Upload request: library={library_id} user={user_id} "
@@ -676,6 +657,7 @@ async def upload_and_index_document_async(
     http_request: Request,
     file: UploadFile = File(..., description="Raw attachment bytes"),
     metadata: str = Form(...),
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """
@@ -690,7 +672,7 @@ async def upload_and_index_document_async(
     """
     meta_dict, doc_metadata, library_id, item_key, attachment_key, user_id, \
         library_type, mime_type, item_version, attachment_version, item_modified, \
-        file_bytes = await _parse_upload_request(file, metadata)
+        file_bytes = await _parse_upload_request(file, metadata, identity)
 
     logger.info(
         f"Async upload request: library={library_id} user={user_id} "
@@ -788,6 +770,7 @@ async def get_upload_task_status(task_id: str):
 async def upload_and_index_abstract(
     http_request: Request,
     request: AbstractIndexRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """
@@ -798,10 +781,11 @@ async def upload_and_index_abstract(
     The abstract must meet the configured minimum word count (MIN_ABSTRACT_WORDS).
     """
     settings = get_settings()
-    _check_registration(request.library_id, request.user_id, settings)
+    assert_can_access(identity, request.library_id)
+    user_id = identity.user_id if identity else None
     word_count = len(request.abstract_text.split())
     logger.info(
-        f"Abstract index: library={request.library_id} user={request.user_id} "
+        f"Abstract index: library={request.library_id} user={user_id} "
         f"item={request.item_key} words={word_count}"
     )
     if word_count < settings.min_abstract_words:
@@ -899,6 +883,7 @@ async def upload_and_index_abstract(
 )
 def batch_update_metadata(
     request: BatchMetadataUpdateRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """
@@ -911,6 +896,7 @@ def batch_update_metadata(
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, request.library_id)
 
     updated_items = 0
     updated_chunks = 0
@@ -955,11 +941,12 @@ def batch_update_metadata(
 # ---------------------------------------------------------------------------
 
 
-async def _parse_upload_request(file: UploadFile, metadata: str):
+async def _parse_upload_request(file: UploadFile, metadata: str, identity: Optional[ZoteroIdentity]):
     """Parse and validate the common multipart upload fields.
 
     Returns a tuple of all parsed fields needed by both sync and async endpoints.
-    Raises HTTPException 400 on validation errors.
+    Raises HTTPException 400 on validation errors, or 403 if the caller's identity
+    is not authorized for the requested library_id.
     """
     try:
         meta_dict = json.loads(metadata)
@@ -977,8 +964,8 @@ async def _parse_upload_request(file: UploadFile, metadata: str):
     library_id: str = meta_dict["library_id"]
     item_key: str = meta_dict["item_key"]
     attachment_key: str = meta_dict["attachment_key"]
-    user_id: Optional[int] = meta_dict.get("user_id")
-    _check_registration(library_id, user_id, get_settings())
+    assert_can_access(identity, library_id)
+    user_id: Optional[int] = identity.user_id if identity else meta_dict.get("user_id")
     library_type: str = meta_dict.get("library_type", "user")
     mime_type: str = meta_dict.get("mime_type", "application/pdf")
     item_version: int = int(meta_dict.get("item_version", 0))

--- a/backend/api/libraries.py
+++ b/backend/api/libraries.py
@@ -12,7 +12,7 @@ from backend.models.library import LibraryIndexMetadata
 from backend.db.vector_store import VectorStore
 from backend.dependencies import get_vector_store, get_zotero_identity
 from backend.config.settings import get_settings
-from backend.services.access_gate import assert_can_access
+from backend.services.access_gate import assert_can_access, is_authorized_for_library
 from backend.services.registration_service import RegistrationService
 from backend.services.zotero_identity import ZoteroIdentity
 
@@ -101,7 +101,7 @@ def list_libraries(
     # Union of all known library IDs (indexed + registered)
     all_ids = set(metadata_by_id.keys()) | set(registrations.keys())
     if identity is not None:
-        all_ids &= set(identity.targets)
+        all_ids = {lid for lid in all_ids if is_authorized_for_library(identity, lid)}
 
     return [
         _build_detail(lid, metadata_by_id.get(lid), registrations.get(lid))

--- a/backend/api/libraries.py
+++ b/backend/api/libraries.py
@@ -110,12 +110,17 @@ def list_libraries(
 
 
 @router.get("/libraries/{library_id}/status", response_model=LibraryDetailResponse)
-def get_library_status(library_id: str, vector_store: VectorStore = Depends(get_vector_store)):
+def get_library_status(
+    library_id: str,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
     """
     Get combined status for a single library: index metadata and registrations.
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
 
     settings = get_settings()
     reg_service = RegistrationService(settings.registrations_path)
@@ -131,15 +136,21 @@ def get_library_status(library_id: str, vector_store: VectorStore = Depends(get_
 
 
 @router.get("/libraries/{library_id}/index-status", response_model=LibraryIndexMetadata)
-def get_library_index_status(library_id: str, vector_store: VectorStore = Depends(get_vector_store)):
+def get_library_index_status(
+    library_id: str,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
     """
     Get detailed indexing metadata for a library (used by the plugin to track sync state).
 
     Raises:
-        HTTPException: 404 if library has never been indexed, 503 if store unavailable.
+        HTTPException: 403 if the caller's Zotero key doesn't grant access to
+        this library, 404 if library has never been indexed, 503 if store unavailable.
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
 
     try:
         metadata = vector_store.get_library_metadata(library_id)
@@ -184,7 +195,11 @@ def clear_library_index(
 
 
 @router.post("/libraries/{library_id}/reconcile-count", response_model=LibraryIndexMetadata)
-def reconcile_library_count(library_id: str, vector_store: VectorStore = Depends(get_vector_store)):
+def reconcile_library_count(
+    library_id: str,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
     """
     Recompute total_items_indexed from actual vector store data and persist it.
 
@@ -193,6 +208,7 @@ def reconcile_library_count(library_id: str, vector_store: VectorStore = Depends
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
 
     meta = vector_store.get_library_metadata(library_id)
     if meta is None:

--- a/backend/api/libraries.py
+++ b/backend/api/libraries.py
@@ -10,9 +10,11 @@ from typing import Optional
 
 from backend.models.library import LibraryIndexMetadata
 from backend.db.vector_store import VectorStore
-from backend.dependencies import get_vector_store
+from backend.dependencies import get_vector_store, get_zotero_identity
 from backend.config.settings import get_settings
+from backend.services.access_gate import assert_can_access
 from backend.services.registration_service import RegistrationService
+from backend.services.zotero_identity import ZoteroIdentity
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -78,11 +80,13 @@ def _build_detail(
 
 
 @router.get("/libraries", response_model=list[LibraryDetailResponse])
-def list_libraries(vector_store: VectorStore = Depends(get_vector_store)):
+def list_libraries(
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
     """
-    List all libraries known to the backend (indexed or registered).
-
-    Returns combined index metadata, registration info, and storage stats for each.
+    List libraries known to the backend (indexed or registered), filtered to
+    the caller's own readable targets when authenticated via a Zotero key.
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
@@ -96,6 +100,8 @@ def list_libraries(vector_store: VectorStore = Depends(get_vector_store)):
 
     # Union of all known library IDs (indexed + registered)
     all_ids = set(metadata_by_id.keys()) | set(registrations.keys())
+    if identity is not None:
+        all_ids &= set(identity.targets)
 
     return [
         _build_detail(lid, metadata_by_id.get(lid), registrations.get(lid))
@@ -149,13 +155,18 @@ def get_library_index_status(library_id: str, vector_store: VectorStore = Depend
         raise HTTPException(status_code=500, detail=f"Failed to retrieve library index status: {str(e)}")
 
 
-@router.delete("/libraries/{library_id}/index")
-def clear_library_index(library_id: str, vector_store: VectorStore = Depends(get_vector_store)):
+@router.delete("/libraries/{library_id:path}/index")
+def clear_library_index(
+    library_id: str,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
     """
     Remove all indexed data for a library (chunks, dedup records, metadata).
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
 
     try:
         chunks_deleted = vector_store.delete_library_chunks(library_id)
@@ -231,10 +242,11 @@ class SyncDeletionsResponse(BaseModel):
     deleted_chunks: int
 
 
-@router.post("/libraries/{library_id}/sync-deletions", response_model=SyncDeletionsResponse)
+@router.post("/libraries/{library_id:path}/sync-deletions", response_model=SyncDeletionsResponse)
 def sync_library_deletions(
     library_id: str,
     request: SyncDeletionsRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """Remove chunks for indexed items no longer present in the Zotero library.
@@ -246,6 +258,7 @@ def sync_library_deletions(
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
 
     try:
         indexed = vector_store.get_all_indexed_item_versions(library_id)
@@ -270,13 +283,19 @@ def sync_library_deletions(
         raise HTTPException(status_code=500, detail=f"sync-deletions failed: {str(e)}")
 
 
-@router.delete("/libraries/{library_id}/items/{item_key}/chunks")
-def clear_item_chunks(library_id: str, item_key: str, vector_store: VectorStore = Depends(get_vector_store)):
+@router.delete("/libraries/{library_id:path}/items/{item_key}/chunks")
+def clear_item_chunks(
+    library_id: str,
+    item_key: str,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
     """
     Remove all indexed chunks for a specific item within a library.
     """
     if vector_store is None:
         raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
 
     try:
         chunks_deleted = vector_store.delete_item_chunks(library_id, item_key)

--- a/backend/api/query.py
+++ b/backend/api/query.py
@@ -11,11 +11,13 @@ from typing import List, Optional
 from markdown_it import MarkdownIt
 
 from backend.models.trace import QueryTrace
+from backend.services.access_gate import assert_can_access
 from backend.services.query_orchestrator import QueryOrchestrator
 from backend.services.trace_collector import TraceCollector
+from backend.services.zotero_identity import ZoteroIdentity
 from backend.db.vector_store import VectorStore
 from backend.config.settings import get_settings
-from backend.dependencies import get_client_api_keys, get_vector_store, make_embedding_service, make_llm_service
+from backend.dependencies import get_client_api_keys, get_vector_store, get_zotero_identity, make_embedding_service, make_llm_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -59,6 +61,7 @@ class QueryResponse(BaseModel):
 async def query_libraries(
     query: QueryRequest,
     http_request: Request,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
     vector_store: VectorStore = Depends(get_vector_store),
 ):
     """
@@ -81,6 +84,9 @@ async def query_libraries(
             status_code=400,
             detail="At least one library ID must be provided"
         )
+
+    for library_id in query.library_ids:
+        assert_can_access(identity, library_id)
 
     if not query.question.strip():
         raise HTTPException(

--- a/backend/api/registration.py
+++ b/backend/api/registration.py
@@ -47,16 +47,21 @@ async def register_library(
     """Associate a zotero.org user with a library on this backend.
 
     Returns ``exists: true`` if this library was already registered by any
-    user before this call.
+    user before this call. The registered user_id/username are taken from
+    the caller's validated Zotero identity when present, never trusted from
+    the request body — only the loopback/legacy no-identity path falls back
+    to the body-supplied values.
     """
     assert_can_access(identity, request.library_id)
     settings = get_settings()
     service = RegistrationService(settings.registrations_path)
+    user_id = identity.user_id if identity else request.user_id
+    username = identity.username if identity else request.username
     existed = service.register(
         library_id=request.library_id,
         library_name=request.library_name,
-        user_id=request.user_id,
-        username=request.username,
+        user_id=user_id,
+        username=username,
     )
     return RegisterResponse(exists=existed)
 

--- a/backend/api/registration.py
+++ b/backend/api/registration.py
@@ -2,15 +2,19 @@
 Library/user registration endpoints.
 
 POST /api/register   — register a user for a library
-GET  /api/registrations — inspect all registration data (admin)
+GET  /api/registrations — inspect registration data for the caller's accessible libraries
 """
 
 import logging
+from typing import Optional
 from pydantic import BaseModel
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from backend.config.settings import get_settings
+from backend.dependencies import get_zotero_identity
+from backend.services.access_gate import assert_can_access, is_authorized_for_library
 from backend.services.registration_service import RegistrationService
+from backend.services.zotero_identity import ZoteroIdentity
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -36,13 +40,16 @@ class RegisterResponse(BaseModel):
     response_model=RegisterResponse,
     summary="Register a user for a library",
 )
-async def register_library(request: RegisterRequest) -> RegisterResponse:
+async def register_library(
+    request: RegisterRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+) -> RegisterResponse:
     """Associate a zotero.org user with a library on this backend.
 
-    Must be called before the first indexing operation for a library when
-    REQUIRE_REGISTRATION is enabled. Returns ``exists: true`` if this library
-    was already registered by any user before this call.
+    Returns ``exists: true`` if this library was already registered by any
+    user before this call.
     """
+    assert_can_access(identity, request.library_id)
     settings = get_settings()
     service = RegistrationService(settings.registrations_path)
     existed = service.register(
@@ -56,13 +63,26 @@ async def register_library(request: RegisterRequest) -> RegisterResponse:
 
 @router.get(
     "/registrations",
-    summary="Inspect all library/user registration data (admin)",
+    summary="Inspect library/user registration data for the caller's accessible libraries",
 )
-async def get_registrations() -> dict:
-    """Return the full registrations JSON for admin inspection.
+async def get_registrations(
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+) -> dict:
+    """Return registration data, filtered to the caller's own readable libraries.
 
-    Protected by the same API key auth as all other endpoints.
+    On loopback deployments (identity=None) returns the full registrations
+    file unfiltered, matching the single-trusted-local-user model used
+    throughout this backend's Zotero-key auth. On a gated remote deployment,
+    each caller sees only registrations for libraries their own Zotero key
+    grants read access to — the same filtering GET /api/libraries applies.
     """
     settings = get_settings()
     service = RegistrationService(settings.registrations_path)
-    return service.get_all()
+    all_registrations = service.get_all()
+    if identity is None:
+        return all_registrations
+    return {
+        library_id: entry
+        for library_id, entry in all_registrations.items()
+        if is_authorized_for_library(identity, library_id)
+    }

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -7,9 +7,10 @@ hardware presets and storage paths.
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import NoDecode
 
 from backend.__version__ import __version__
 from .presets import HardwarePreset, get_preset
@@ -165,6 +166,33 @@ class Settings(BaseSettings):
         description="Zotero API key for cron indexing via api.zotero.org. "
                     "Create at https://www.zotero.org/settings/keys"
     )
+
+    authorized_group_id: Optional[int] = Field(
+        default=None,
+        description="Zotero group ID that gates access to this instance in remote mode. "
+                    "A caller's validated Zotero key must grant read access to "
+                    "groups/<id> (i.e. the caller is a member of this group) to be "
+                    "authorized. Combines with AUTHORIZED_USER_IDS via OR. "
+                    "Ignored on loopback deployments (api_host=localhost/127.0.0.1)."
+    )
+    authorized_user_ids: Annotated[list[int], NoDecode] = Field(
+        default=[],
+        description="Explicit allowlist of Zotero user IDs authorized to use this "
+                    "instance in remote mode, in addition to AUTHORIZED_GROUP_ID "
+                    "membership (OR semantics). Comma-separated list of integers "
+                    "in the environment. At least one of AUTHORIZED_GROUP_ID / "
+                    "AUTHORIZED_USER_IDS must be set for the server to start in "
+                    "remote mode — see backend.services.access_gate.assert_safe_to_start."
+    )
+
+    @field_validator("authorized_user_ids", mode="before")
+    @classmethod
+    def parse_authorized_user_ids(cls, v):
+        if isinstance(v, list):
+            return [int(x) for x in v]
+        if isinstance(v, str):
+            return [int(x.strip()) for x in v.split(",") if x.strip()]
+        return v
 
     require_registration: bool = Field(
         default=True,

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -194,12 +194,6 @@ class Settings(BaseSettings):
             return [int(x.strip()) for x in v.split(",") if x.strip()]
         return v
 
-    require_registration: bool = Field(
-        default=True,
-        description="Require users to register before indexing. "
-                    "Automatically skipped when api_host is localhost or 127.0.0.1."
-    )
-
     testing: bool = Field(
         default=False,
         description="Testing mode: use mock embedding/LLM services (no API keys or model downloads required)"

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -34,12 +34,6 @@ class Settings(BaseSettings):
     # API Configuration
     api_host: str = Field(default="localhost", description="API server host")
     api_port: int = Field(default=8119, description="API server port")
-    api_key: Optional[str] = Field(
-        default=None,
-        description="API key for remote access (X-API-Key header). "
-                    "When set, all requests must include this key. "
-                    "Leave unset for local-only deployments."
-    )
     public_libraries_config: Optional[str] = Field(
         default=None,
         description="Path to JSON file listing publicly exposed library slugs "

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -63,9 +63,9 @@ def get_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
 
     The auth middleware in backend/main.py sets request.state.zotero_identity
     on every /api/* request (calling resolve_zotero_identity once), so this
-    simply reads back that live value. It returns None on loopback deployments
-    and for the transitional legacy-shared-key path, both of which
-    access_gate.assert_can_access() treats as "skip per-library enforcement".
+    simply reads back that live value. It returns None on loopback
+    deployments, which access_gate.assert_can_access() treats as "skip
+    per-library enforcement".
     """
     return getattr(request.state, "zotero_identity", None)
 

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -9,14 +9,65 @@ import json
 import logging
 import re
 from pathlib import Path
-from fastapi import Request
+from typing import Optional
+from fastapi import HTTPException, Request
 
 from backend.config.settings import get_settings
 from backend.db.vector_store import VectorStore
+from backend.services.access_gate import is_loopback, passes_gate
 from backend.services.embeddings import EmbeddingService, create_embedding_service, RemoteEmbeddingService
 from backend.services.llm import LLMService, create_llm_service, RemoteLLMService
+from backend.services.zotero_identity import ZoteroIdentity, get_identity_cache
 
 logger = logging.getLogger(__name__)
+
+
+async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
+    """Resolve and gate the caller's Zotero identity for the current request.
+
+    Returns None for the loopback no-auth path (Part 4) and for the
+    transitional legacy-shared-key path (Part 5) — both skip per-library
+    enforcement in access_gate.assert_can_access(). Raises HTTPException:
+    401 for a missing/invalid/revoked key, 403 if the Part 2 gate rejects
+    an otherwise-valid identity, 503 if zotero.org is unreachable with no
+    cached validation to fall back on.
+
+    Used both as a FastAPI dependency (directly, or via get_zotero_identity
+    reading back what the api_key_middleware already resolved) and as the
+    middleware's own auth check for every /api/* request.
+    """
+    settings = get_settings()
+    if is_loopback(settings):
+        return None
+
+    zotero_key = request.headers.get("X-Zotero-API-Key")
+    if not zotero_key:
+        legacy_key = request.headers.get("X-API-Key") or request.query_params.get("api_key")
+        if settings.api_key and legacy_key == settings.api_key:
+            logger.warning("Request authenticated via legacy shared API_KEY (transitional path)")
+            return None
+        raise HTTPException(status_code=401, detail="Missing X-Zotero-API-Key header.")
+
+    validation = await get_identity_cache().resolve(zotero_key)
+    if not validation.read_only:
+        status_code = 503 if validation.transient else 401
+        raise HTTPException(status_code=status_code, detail=validation.reason or "Invalid Zotero API key.")
+
+    identity = ZoteroIdentity(user_id=validation.user_id, username=validation.username, targets=validation.targets)
+    if not passes_gate(identity, settings):
+        raise HTTPException(status_code=403, detail="This Zotero account is not authorized to use this server.")
+    return identity
+
+
+def get_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
+    """FastAPI dependency: read back the identity api_key_middleware resolved.
+
+    Route handlers should depend on this (not resolve_zotero_identity
+    directly) to avoid re-validating the key a second time per request.
+    Returns None if the middleware never ran for this path (shouldn't
+    happen for any /api/* route) or resolved to the loopback/legacy path.
+    """
+    return getattr(request.state, "zotero_identity", None)
 
 
 def get_client_api_keys(request: Request) -> dict[str, str]:

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -25,12 +25,11 @@ logger = logging.getLogger(__name__)
 async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
     """Resolve and gate the caller's Zotero identity for the current request.
 
-    Returns None for the loopback no-auth path (Part 4) and for the
-    transitional legacy-shared-key path (Part 5) — both skip per-library
-    enforcement in access_gate.assert_can_access(). Raises HTTPException:
-    401 for a missing/invalid/revoked key, 403 if the Part 2 gate rejects
-    an otherwise-valid identity, 503 if zotero.org is unreachable with no
-    cached validation to fall back on.
+    Returns None for the loopback no-auth path (Part 4) — single trusted local
+    user, no per-library enforcement needed (see access_gate.assert_can_access()).
+    Raises HTTPException: 401 for a missing/invalid/revoked key, 403 if the
+    Part 2 gate rejects an otherwise-valid identity, 503 if zotero.org is
+    unreachable with no cached validation to fall back on.
 
     Called once per request by the auth middleware in backend/main.py, which
     stashes the result on request.state.zotero_identity for every /api/*
@@ -43,10 +42,6 @@ async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
 
     zotero_key = request.headers.get("X-Zotero-API-Key")
     if not zotero_key:
-        legacy_key = request.headers.get("X-API-Key") or request.query_params.get("api_key")
-        if settings.api_key and legacy_key == settings.api_key:
-            logger.warning("Request authenticated via legacy shared API_KEY (transitional path)")
-            return None
         raise HTTPException(status_code=401, detail="Missing X-Zotero-API-Key header.")
 
     validation = await get_identity_cache().resolve(zotero_key)

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -32,9 +32,10 @@ async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
     an otherwise-valid identity, 503 if zotero.org is unreachable with no
     cached validation to fall back on.
 
-    Used both as a FastAPI dependency (directly, or via get_zotero_identity
-    reading back what the api_key_middleware already resolved) and as the
-    middleware's own auth check for every /api/* request.
+    Called once per request by the auth middleware (added in a later task),
+    which stashes the result on request.state.zotero_identity. Route
+    handlers should depend on get_zotero_identity instead, not this
+    function directly, to avoid re-validating the key a second time.
     """
     settings = get_settings()
     if is_loopback(settings):
@@ -60,12 +61,15 @@ async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
 
 
 def get_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
-    """FastAPI dependency: read back the identity api_key_middleware resolved.
+    """FastAPI dependency: read back the identity the auth middleware resolved.
 
-    Route handlers should depend on this (not resolve_zotero_identity
-    directly) to avoid re-validating the key a second time per request.
-    Returns None if the middleware never ran for this path (shouldn't
-    happen for any /api/* route) or resolved to the loopback/legacy path.
+    Route handlers should depend on this — not resolve_zotero_identity
+    directly — to avoid re-validating the key a second time per request.
+
+    NOTE: no middleware currently sets request.state.zotero_identity (that
+    wiring lands in a later task); until then this always returns None,
+    which access_gate.assert_can_access() correctly treats as "skip
+    per-library enforcement" — the same as today's pre-this-plan behavior.
     """
     return getattr(request.state, "zotero_identity", None)
 

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -32,10 +32,10 @@ async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
     an otherwise-valid identity, 503 if zotero.org is unreachable with no
     cached validation to fall back on.
 
-    Called once per request by the auth middleware (added in a later task),
-    which stashes the result on request.state.zotero_identity. Route
-    handlers should depend on get_zotero_identity instead, not this
-    function directly, to avoid re-validating the key a second time.
+    Called once per request by the auth middleware in backend/main.py, which
+    stashes the result on request.state.zotero_identity for every /api/*
+    request. Route handlers should depend on get_zotero_identity instead,
+    not this function directly, to avoid re-validating the key a second time.
     """
     settings = get_settings()
     if is_loopback(settings):
@@ -66,10 +66,11 @@ def get_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
     Route handlers should depend on this — not resolve_zotero_identity
     directly — to avoid re-validating the key a second time per request.
 
-    NOTE: no middleware currently sets request.state.zotero_identity (that
-    wiring lands in a later task); until then this always returns None,
-    which access_gate.assert_can_access() correctly treats as "skip
-    per-library enforcement" — the same as today's pre-this-plan behavior.
+    The auth middleware in backend/main.py sets request.state.zotero_identity
+    on every /api/* request (calling resolve_zotero_identity once), so this
+    simply reads back that live value. It returns None on loopback deployments
+    and for the transitional legacy-shared-key path, both of which
+    access_gate.assert_can_access() treats as "skip per-library enforcement".
     """
     return getattr(request.state, "zotero_identity", None)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ FastAPI application entry point for Zotero RAG backend.
 
 import asyncio
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 import httpx
@@ -13,12 +13,14 @@ import logging
 from backend.__version__ import __version__
 from backend.config.settings import get_settings
 from backend.db.vector_store import VectorStore
-from backend.dependencies import make_vector_store
+from backend.dependencies import make_vector_store, resolve_zotero_identity
+from backend.services.access_gate import assert_safe_to_start
 from backend.api import config, libraries, indexing, query, document_upload, registration, rate_limits, public_query, autoindex
 from backend.api.document_upload import load_item_cache, save_item_cache
 
 # Get settings to access log configuration
 settings = get_settings()
+assert_safe_to_start(settings)
 
 # Configure logging with both console and file output
 # Use UTF-8 encoding to handle Unicode characters in document titles/metadata
@@ -137,34 +139,41 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
     return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
 
 
-# API key authentication middleware
-# Exempt health-check / version endpoints so the plugin can discover the backend
-# without needing credentials first.
+# Zotero-key identity middleware
+# Resolves and gates the caller's identity for every /api/* request — see
+# docs/history/plan-zotero-key-auth.md for the design. Exempt health-check /
+# version endpoints so the plugin can discover the backend without needing
+# credentials first, and /public/* which is intentionally unauthenticated.
 _AUTH_EXEMPT_PATHS = {"/", "/health", "/api/version"}
 
 
 @app.middleware("http")
 async def api_key_middleware(request: Request, call_next):
-    """Validate X-API-Key when api_key is configured.
+    """Resolve and gate the caller's Zotero identity for every /api/* request.
 
-    Accepts the key via:
-    - X-API-Key request header  (all endpoints)
-    - ?api_key= query parameter (SSE endpoints where EventSource cannot set headers)
+    Loopback deployments (api_host in {localhost, 127.0.0.1}) skip this
+    entirely (Part 4) — there is exactly one trusted local user. Everywhere
+    else the caller must present either a valid, gate-approved Zotero API
+    key (X-Zotero-API-Key) or, during the transitional migration window, the
+    legacy shared secret (X-API-Key header / ?api_key= query param — the
+    latter for SSE endpoints where EventSource cannot set headers). The
+    resolved identity (or None for loopback/legacy) is stashed on
+    request.state.zotero_identity so downstream route dependencies
+    (backend.dependencies.get_zotero_identity) don't re-validate.
 
-    OPTIONS requests (CORS preflight) and health/version endpoints are always
-    allowed so the browser can complete the preflight handshake and the plugin
-    can discover the backend without credentials.
+    OPTIONS requests (CORS preflight) are always allowed so the browser can
+    complete the preflight handshake.
     """
+    request.state.zotero_identity = None
     if (
-        settings.api_key
-        and request.method != "OPTIONS"
+        request.method != "OPTIONS"
+        and request.url.path.startswith("/api/")
         and request.url.path not in _AUTH_EXEMPT_PATHS
-        and not request.url.path.startswith("/public")
     ):
-        header_key = request.headers.get("X-API-Key")
-        query_key = request.query_params.get("api_key")
-        if header_key != settings.api_key and query_key != settings.api_key:
-            return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+        try:
+            request.state.zotero_identity = await resolve_zotero_identity(request)
+        except HTTPException as exc:
+            return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
     return await call_next(request)
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -153,12 +153,9 @@ async def api_key_middleware(request: Request, call_next):
 
     Loopback deployments (api_host in {localhost, 127.0.0.1}) skip this
     entirely (Part 4) — there is exactly one trusted local user. Everywhere
-    else the caller must present either a valid, gate-approved Zotero API
-    key (X-Zotero-API-Key) or, during the transitional migration window, the
-    legacy shared secret (X-API-Key header / ?api_key= query param — the
-    latter for SSE endpoints where EventSource cannot set headers). The
-    resolved identity (or None for loopback/legacy) is stashed on
-    request.state.zotero_identity so downstream route dependencies
+    else the caller must present a valid, gate-approved Zotero API key
+    (X-Zotero-API-Key). The resolved identity (or None for loopback) is
+    stashed on request.state.zotero_identity so downstream route dependencies
     (backend.dependencies.get_zotero_identity) don't re-validate.
 
     OPTIONS requests (CORS preflight) are always allowed so the browser can

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,7 +15,7 @@ from backend.config.settings import get_settings
 from backend.db.vector_store import VectorStore
 from backend.dependencies import make_vector_store, resolve_zotero_identity
 from backend.services.access_gate import assert_safe_to_start
-from backend.api import config, libraries, indexing, query, document_upload, registration, rate_limits, public_query, autoindex
+from backend.api import config, libraries, indexing, query, document_upload, registration, rate_limits, public_query, autoindex, auth
 from backend.api.document_upload import load_item_cache, save_item_cache
 
 # Get settings to access log configuration
@@ -193,6 +193,7 @@ app.include_router(registration.router, prefix="/api", tags=["registration"])
 app.include_router(rate_limits.router, prefix="/api", tags=["rate-limits"])
 app.include_router(public_query.router, tags=["public"])
 app.include_router(autoindex.router, prefix="/api", tags=["autoindex"])
+app.include_router(auth.router, prefix="/api", tags=["auth"])
 
 
 @app.get("/")

--- a/backend/services/access_gate.py
+++ b/backend/services/access_gate.py
@@ -1,0 +1,72 @@
+"""The Part 2 access gate and Part 4 loopback exception.
+
+zotero_identity.py proves "this is a real Zotero user with these readable
+libraries." That is authentication, not authorization to use this instance —
+any Zotero account on earth can pass it. This module adds the second check:
+is the identity a member of a designated Zotero group, or on an explicit
+user_id allowlist? It also holds the per-library enforcement helper used by
+route handlers, and the startup check that refuses to run an unguarded
+remote instance.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import HTTPException
+
+from backend.config.settings import Settings
+from backend.services.zotero_identity import ZoteroIdentity
+
+logger = logging.getLogger(__name__)
+
+
+def is_loopback(settings: Settings) -> bool:
+    """True for the single-trusted-local-user deployment mode (Part 4)."""
+    return settings.api_host in ("localhost", "127.0.0.1")
+
+
+def is_gate_configured(settings: Settings) -> bool:
+    return bool(settings.authorized_group_id) or bool(settings.authorized_user_ids)
+
+
+def passes_gate(identity: ZoteroIdentity, settings: Settings) -> bool:
+    """True if identity is allowed to use this instance at all (Part 2)."""
+    if settings.authorized_group_id and f"groups/{settings.authorized_group_id}" in identity.targets:
+        return True
+    if settings.authorized_user_ids and identity.user_id in settings.authorized_user_ids:
+        return True
+    return False
+
+
+def assert_safe_to_start(settings: Settings) -> None:
+    """Refuse to start in remote mode without a configured access gate.
+
+    Loopback deployments are exempt: a single trusted local user needs no
+    gate. Remote deployments must configure AUTHORIZED_GROUP_ID and/or
+    AUTHORIZED_USER_IDS, or every Zotero user on earth could use the instance.
+    """
+    if is_loopback(settings):
+        return
+    if not is_gate_configured(settings):
+        raise RuntimeError(
+            f"Refusing to start in remote mode (api_host={settings.api_host!r}) "
+            "without an access gate: set AUTHORIZED_GROUP_ID and/or "
+            "AUTHORIZED_USER_IDS. See docs/history/plan-zotero-key-auth.md Part 2."
+        )
+
+
+def assert_can_access(identity: Optional[ZoteroIdentity], library_id: str) -> None:
+    """Raise 403 unless library_id is within identity's readable targets.
+
+    identity=None means the caller is on the loopback no-auth path (Part 4)
+    or the transitional legacy-shared-key path (Part 5) — both bypass
+    per-library enforcement (loopback because there is only one trusted
+    user; legacy because un-migrated plugins predate per-library targets).
+    """
+    if identity is None:
+        return
+    if library_id not in identity.targets:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Your Zotero key does not grant read access to library {library_id!r}.",
+        )

--- a/backend/services/access_gate.py
+++ b/backend/services/access_gate.py
@@ -55,6 +55,35 @@ def assert_safe_to_start(settings: Settings) -> None:
         )
 
 
+def _backend_id_to_slug(backend_id: str) -> str:
+    """Convert a backend library ID to a Zotero.org slug for target comparison.
+
+    u12345 -> users/12345
+    678    -> groups/678
+
+    Duplicated from backend.api.public_query.backend_id_to_slug (not imported
+    from there) to avoid a circular import: backend/dependencies.py already
+    imports from this module, and public_query.py imports from dependencies.py.
+    """
+    if backend_id.startswith("u"):
+        return "users/" + backend_id[1:]
+    return "groups/" + backend_id
+
+
+def is_authorized_for_library(identity: Optional[ZoteroIdentity], library_id: str) -> bool:
+    """True if identity may access library_id.
+
+    identity=None means the loopback (Part 4) or legacy-shared-key (Part 5)
+    bypass path — always authorized. Otherwise library_id (backend format,
+    e.g. "u12345" or "678") is converted to Zotero slug format (e.g.
+    "users/12345" or "groups/678") before checking identity.targets, since
+    the two use different ID formats — see _backend_id_to_slug.
+    """
+    if identity is None:
+        return True
+    return _backend_id_to_slug(library_id) in identity.targets
+
+
 def assert_can_access(identity: Optional[ZoteroIdentity], library_id: str) -> None:
     """Raise 403 unless library_id is within identity's readable targets.
 
@@ -63,9 +92,7 @@ def assert_can_access(identity: Optional[ZoteroIdentity], library_id: str) -> No
     per-library enforcement (loopback because there is only one trusted
     user; legacy because un-migrated plugins predate per-library targets).
     """
-    if identity is None:
-        return
-    if library_id not in identity.targets:
+    if not is_authorized_for_library(identity, library_id):
         raise HTTPException(
             status_code=403,
             detail=f"Your Zotero key does not grant read access to library {library_id!r}.",

--- a/backend/services/registration_service.py
+++ b/backend/services/registration_service.py
@@ -73,16 +73,6 @@ class RegistrationService:
             self._save(data)
         return existed
 
-    def is_registered(self, library_id: str, user_id: int | None) -> bool:
-        """Return True if user_id is in the registered users list for library_id."""
-        if user_id is None:
-            return False
-        data = self._load()
-        entry = data.get(library_id)
-        if entry is None:
-            return False
-        return any(u["user_id"] == user_id for u in entry.get("users", []))
-
     def get_all(self) -> dict:
         """Return the full registrations dict."""
         return self._load()

--- a/backend/services/zotero_identity.py
+++ b/backend/services/zotero_identity.py
@@ -1,0 +1,72 @@
+"""Zotero-key identity resolution and caching (Part 1.3 of the design).
+
+A Zotero API key resolves to a stable identity — (user_id, username, targets)
+— via backend.zotero.key_validator.validate_key(), which calls
+api.zotero.org. That call is too slow and too fragile to make on every
+request, so ZoteroIdentityCache caches the result per key fingerprint with a
+TTL. A transient zotero.org failure (5xx, network error) serves a still-cached
+entry rather than failing the request; a hard failure (revoked key, write
+scope, no readable library) always overwrites the cache so it is never masked
+by stale "valid" data.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+
+from backend.zotero.key_validator import KeyValidation, validate_key
+from backend.services.autoindex_key_store import fingerprint
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 600
+
+
+@dataclass
+class ZoteroIdentity:
+    """A validated, gate-approved Zotero identity resolved from an API key."""
+
+    user_id: int
+    username: str
+    targets: list[str]
+
+
+class ZoteroIdentityCache:
+    """In-memory TTL cache of KeyValidation results, keyed by key fingerprint."""
+
+    def __init__(self, ttl_seconds: int = CACHE_TTL_SECONDS) -> None:
+        self._ttl = ttl_seconds
+        self._entries: dict[str, tuple[float, KeyValidation]] = {}
+
+    async def resolve(self, api_key: str) -> KeyValidation:
+        """Return a cached or freshly validated KeyValidation for api_key."""
+        fp = fingerprint(api_key)
+        now = time.monotonic()
+        cached = self._entries.get(fp)
+        if cached is not None and now - cached[0] < self._ttl:
+            return cached[1]
+
+        result = await validate_key(api_key)
+        if result.transient and cached is not None:
+            logger.warning("zotero.org validation failed transiently; serving stale cache for %s", fp)
+            return cached[1]
+        if not result.transient:
+            self._entries[fp] = (now, result)
+        return result
+
+    def clear(self) -> None:
+        """Test helper: drop all cached entries."""
+        self._entries.clear()
+
+
+_cache = ZoteroIdentityCache()
+
+
+def get_identity_cache() -> ZoteroIdentityCache:
+    """Return the process-wide identity cache used by the auth middleware."""
+    return _cache
+
+
+def reset_identity_cache() -> None:
+    """Test helper: clear the process-wide cache between test cases."""
+    _cache.clear()

--- a/backend/tests/test_access_gate.py
+++ b/backend/tests/test_access_gate.py
@@ -81,12 +81,32 @@ class AssertCanAccessTest(unittest.TestCase):
 
     def test_identity_with_target_allowed(self):
         identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
-        assert_can_access(identity, "users/1")  # must not raise
+        assert_can_access(identity, "u1")  # must not raise
 
     def test_identity_without_target_rejected(self):
         identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
         with self.assertRaises(HTTPException) as ctx:
-            assert_can_access(identity, "users/2")
+            assert_can_access(identity, "u2")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+
+class RealisticIdFormatTest(unittest.TestCase):
+    """Regression tests: library_id arrives in backend format ('u12345',
+    '678'); identity.targets are in Zotero slug format ('users/12345',
+    'groups/678'). assert_can_access must convert before comparing."""
+
+    def test_backend_user_id_matches_slug_target(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/12345"])
+        assert_can_access(identity, "u12345")  # must not raise
+
+    def test_backend_group_id_matches_slug_target(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["groups/678"])
+        assert_can_access(identity, "678")  # must not raise
+
+    def test_mismatched_backend_user_id_still_rejected(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/12345"])
+        with self.assertRaises(HTTPException) as ctx:
+            assert_can_access(identity, "u99999")
         self.assertEqual(ctx.exception.status_code, 403)
 
 

--- a/backend/tests/test_access_gate.py
+++ b/backend/tests/test_access_gate.py
@@ -1,0 +1,94 @@
+"""Unit tests for backend.services.access_gate (Part 2 gate, Part 4 loopback
+exception, and the per-library enforcement helper used by route handlers)."""
+
+import unittest
+
+from fastapi import HTTPException
+
+from backend.config.settings import Settings
+from backend.services.access_gate import (
+    assert_can_access,
+    assert_safe_to_start,
+    is_gate_configured,
+    is_loopback,
+    passes_gate,
+)
+from backend.services.zotero_identity import ZoteroIdentity
+
+
+class LoopbackTest(unittest.TestCase):
+    def test_localhost_is_loopback(self):
+        self.assertTrue(is_loopback(Settings(api_host="localhost")))
+
+    def test_127_0_0_1_is_loopback(self):
+        self.assertTrue(is_loopback(Settings(api_host="127.0.0.1")))
+
+    def test_fqdn_is_not_loopback(self):
+        self.assertFalse(is_loopback(Settings(api_host="rag.example.com")))
+
+
+class GateConfiguredTest(unittest.TestCase):
+    def test_unconfigured(self):
+        self.assertFalse(is_gate_configured(Settings()))
+
+    def test_group_configured(self):
+        self.assertTrue(is_gate_configured(Settings(authorized_group_id=1)))
+
+    def test_allowlist_configured(self):
+        self.assertTrue(is_gate_configured(Settings(authorized_user_ids=[1])))
+
+
+class PassesGateTest(unittest.TestCase):
+    def test_group_member_passes(self):
+        settings = Settings(authorized_group_id=999)
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1", "groups/999"])
+        self.assertTrue(passes_gate(identity, settings))
+
+    def test_non_member_without_allowlist_fails(self):
+        settings = Settings(authorized_group_id=999)
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self.assertFalse(passes_gate(identity, settings))
+
+    def test_allowlisted_user_passes_even_without_group_membership(self):
+        settings = Settings(authorized_group_id=999, authorized_user_ids=[1])
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self.assertTrue(passes_gate(identity, settings))
+
+    def test_neither_configured_fails_closed(self):
+        settings = Settings()
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1", "groups/999"])
+        self.assertFalse(passes_gate(identity, settings))
+
+
+class AssertSafeToStartTest(unittest.TestCase):
+    def test_loopback_always_safe(self):
+        assert_safe_to_start(Settings(api_host="localhost"))  # must not raise
+
+    def test_remote_without_gate_raises(self):
+        with self.assertRaises(RuntimeError):
+            assert_safe_to_start(Settings(api_host="rag.example.com"))
+
+    def test_remote_with_group_configured_is_safe(self):
+        assert_safe_to_start(Settings(api_host="rag.example.com", authorized_group_id=999))
+
+    def test_remote_with_allowlist_configured_is_safe(self):
+        assert_safe_to_start(Settings(api_host="rag.example.com", authorized_user_ids=[1]))
+
+
+class AssertCanAccessTest(unittest.TestCase):
+    def test_none_identity_always_allowed(self):
+        assert_can_access(None, "users/1")  # must not raise
+
+    def test_identity_with_target_allowed(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        assert_can_access(identity, "users/1")  # must not raise
+
+    def test_identity_without_target_rejected(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        with self.assertRaises(HTTPException) as ctx:
+            assert_can_access(identity, "users/2")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_async_upload.py
+++ b/backend/tests/test_async_upload.py
@@ -74,8 +74,7 @@ class TestAsyncUploadEndpoint(unittest.TestCase):
     def test_duplicate_returns_immediately_no_task_id(self):
         """Content-hash duplicate resolves instantly; no background task is created."""
         self.app.dependency_overrides[self.get_vector_store] = lambda: _mock_vector_store(is_duplicate=True)
-        with patch("backend.api.document_upload._check_registration"):
-            resp = self._post()
+        resp = self._post()
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertEqual(data["status"], "skipped_duplicate")
@@ -92,7 +91,6 @@ class TestAsyncUploadEndpoint(unittest.TestCase):
 
         with (
             patch("backend.api.document_upload.make_embedding_service"),
-            patch("backend.api.document_upload._check_registration"),
             patch("backend.api.document_upload.asyncio.create_task", side_effect=_discard_task),
         ):
             resp = self._post()

--- a/backend/tests/test_auth_whoami.py
+++ b/backend/tests/test_auth_whoami.py
@@ -1,0 +1,64 @@
+"""Tests for GET /api/auth/whoami — used by the plugin's Preferences pane and
+setup wizard to validate a Zotero API key and show the caller's identity."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.zotero_identity import reset_identity_cache
+from backend.zotero.key_validator import KeyValidation
+
+
+class AuthWhoamiTest(unittest.TestCase):
+    def setUp(self):
+        reset_settings()
+        reset_identity_cache()
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        reset_settings()
+        reset_identity_cache()
+
+    def test_loopback_reports_loopback_true(self):
+        r = self.client.get("/api/auth/whoami")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"authorized": True, "loopback": True})
+
+    def test_remote_valid_gated_key_returns_identity(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="alice", targets=["users/1", "groups/999"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/api/auth/whoami", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {
+            "authorized": True,
+            "loopback": False,
+            "user_id": 1,
+            "username": "alice",
+            "targets": ["users/1", "groups/999"],
+        })
+
+    def test_remote_missing_key_is_401(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/api/auth/whoami")
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_ungated_key_is_403(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="alice", targets=["users/1"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/api/auth/whoami", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_autoindex_api.py
+++ b/backend/tests/test_autoindex_api.py
@@ -19,7 +19,6 @@ class AutoIndexApiTest(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         reset_settings()
         s = get_settings()
-        s.api_key = None  # disable auth middleware for the test
         s.autoindex_secret = Fernet.generate_key().decode()
         s.autoindex_keys_path = Path(self.tmp.name) / "autoindex_keys.json"
         s.data_path = Path(self.tmp.name)

--- a/backend/tests/test_autoindex_authorization.py
+++ b/backend/tests/test_autoindex_authorization.py
@@ -1,0 +1,61 @@
+"""Endpoint tests for GET /api/autoindex/keys: results are filtered to the
+caller's own submitted key(s), not every user's."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+from backend.zotero.key_validator import KeyValidation
+import backend.dependencies as dependencies
+
+
+class AutoIndexKeysAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        s.autoindex_secret = Fernet.generate_key().decode()
+        s.autoindex_keys_path = Path(self.tmp.name) / "autoindex_keys.json"
+        self.client = TestClient(app)
+
+        v1 = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        v2 = KeyValidation(user_id=2, username="other", targets=["users/2"], read_only=True)
+        with patch("backend.api.autoindex.validate_key", new=AsyncMock(side_effect=[v1, v2])):
+            self.client.post("/api/autoindex/keys", json={"api_key": "KEY1"})
+            self.client.post("/api/autoindex/keys", json={"api_key": "KEY2"})
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def _set_identity(self, identity):
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def test_list_keys_filters_to_own_user_id(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.get("/api/autoindex/keys")
+        self.assertEqual(r.status_code, 200)
+        user_ids = {k["user_id"] for k in r.json()["keys"]}
+        self.assertEqual(user_ids, {1})
+
+    def test_list_keys_unrestricted_when_no_identity(self):
+        self._set_identity(None)
+        r = self.client.get("/api/autoindex/keys")
+        self.assertEqual(r.status_code, 200)
+        user_ids = {k["user_id"] for k in r.json()["keys"]}
+        self.assertEqual(user_ids, {1, 2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_autoindex_authorization.py
+++ b/backend/tests/test_autoindex_authorization.py
@@ -1,6 +1,7 @@
 """Endpoint tests for GET /api/autoindex/keys: results are filtered to the
 caller's own submitted key(s), not every user's."""
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -55,6 +56,50 @@ class AutoIndexKeysAuthorizationTest(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         user_ids = {k["user_id"] for k in r.json()["keys"]}
         self.assertEqual(user_ids, {1, 2})
+
+    def test_status_filters_slugs_and_key_issues_to_own_identity(self):
+        system_dir = Path(self.tmp.name) / "system"
+        system_dir.mkdir(parents=True, exist_ok=True)
+        (system_dir / "cron_status.json").write_text(json.dumps({
+            "running": False,
+            "slugs": {
+                "users/1": {"status": "done", "items_indexed": 10},
+                "users/2": {"status": "done", "items_indexed": 20},
+            },
+            "key_issues": [
+                {"fingerprint": "abc", "user": "u", "reason": "revoked", "pruned": True},
+                {"fingerprint": "def", "user": "other", "reason": "revoked", "pruned": True},
+            ],
+        }), encoding="utf-8")
+
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.get("/api/autoindex/status")
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertEqual(set(data["slugs"].keys()), {"users/1"})
+        self.assertEqual([i["user"] for i in data["key_issues"]], ["u"])
+
+    def test_status_unrestricted_when_no_identity(self):
+        system_dir = Path(self.tmp.name) / "system"
+        system_dir.mkdir(parents=True, exist_ok=True)
+        (system_dir / "cron_status.json").write_text(json.dumps({
+            "running": False,
+            "slugs": {
+                "users/1": {"status": "done"},
+                "users/2": {"status": "done"},
+            },
+            "key_issues": [
+                {"fingerprint": "abc", "user": "u", "reason": "revoked", "pruned": True},
+                {"fingerprint": "def", "user": "other", "reason": "revoked", "pruned": True},
+            ],
+        }), encoding="utf-8")
+
+        self._set_identity(None)
+        r = self.client.get("/api/autoindex/status")
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertEqual(set(data["slugs"].keys()), {"users/1", "users/2"})
+        self.assertEqual(len(data["key_issues"]), 2)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_document_upload_authorization.py
+++ b/backend/tests/test_document_upload_authorization.py
@@ -85,6 +85,22 @@ class DocumentUploadAuthorizationTest(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 403)
 
+    def test_check_indexed_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/libraries/u2/check-indexed",
+            json={"library_id": "u2", "attachments": []},
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_check_indexed_within_targets_succeeds(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/libraries/u1/check-indexed",
+            json={"library_id": "u1", "attachments": []},
+        )
+        self.assertEqual(r.status_code, 200)
+
     def test_upload_document_body_user_id_is_ignored_in_favor_of_identity(self):
         self._set_identity(ZoteroIdentity(user_id=42, username="real", targets=["users/1"]))
         metadata = json.dumps({

--- a/backend/tests/test_document_upload_authorization.py
+++ b/backend/tests/test_document_upload_authorization.py
@@ -1,0 +1,105 @@
+"""Endpoint tests for backend.api.document_upload authorization:
+- batch metadata update, abstract indexing, and file upload all 403 for a
+  library outside the caller's targets
+- user_id is taken from the validated identity, not the request body
+"""
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.db.vector_store import VectorStore
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+import backend.dependencies as dependencies
+
+
+class DocumentUploadAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        s.testing = True
+        self.client = TestClient(app)
+        app.state.vector_store = VectorStore(
+            storage_path=Path(self.tmp.name) / "qdrant",
+            embedding_dim=8,
+            embedding_model_name="test-model",
+        )
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def _set_identity(self, identity):
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def test_batch_metadata_update_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/index/items/metadata",
+            json={"library_id": "u2", "items": []},
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_batch_metadata_update_within_targets_succeeds(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/index/items/metadata",
+            json={"library_id": "u1", "items": []},
+        )
+        self.assertEqual(r.status_code, 200)
+
+    def test_abstract_index_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/index/abstract",
+            json={
+                "library_id": "u2",
+                "item_key": "ITEM1",
+                "abstract_text": "word " * 200,
+            },
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_upload_document_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        metadata = json.dumps({
+            "library_id": "u2",
+            "item_key": "ITEM1",
+            "attachment_key": "ATT1",
+        })
+        r = self.client.post(
+            "/api/index/document",
+            files={"file": ("doc.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+            data={"metadata": metadata},
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_upload_document_body_user_id_is_ignored_in_favor_of_identity(self):
+        self._set_identity(ZoteroIdentity(user_id=42, username="real", targets=["users/1"]))
+        metadata = json.dumps({
+            "library_id": "u1",
+            "item_key": "ITEM1",
+            "attachment_key": "ATT1",
+            "user_id": 999,  # attacker-supplied — must be ignored
+        })
+        r = self.client.post(
+            "/api/index/document",
+            files={"file": ("doc.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+            data={"metadata": metadata},
+        )
+        self.assertNotEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_libraries_api.py
+++ b/backend/tests/test_libraries_api.py
@@ -94,6 +94,21 @@ class LibrariesAuthorizationTest(unittest.TestCase):
         r = self.client.delete("/api/libraries/u2/items/ITEM1/chunks")
         self.assertEqual(r.status_code, 403)
 
+    def test_get_library_status_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.get("/api/libraries/u2/status")
+        self.assertEqual(r.status_code, 403)
+
+    def test_get_library_index_status_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.get("/api/libraries/u2/index-status")
+        self.assertEqual(r.status_code, 403)
+
+    def test_reconcile_count_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post("/api/libraries/u2/reconcile-count")
+        self.assertEqual(r.status_code, 403)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_libraries_api.py
+++ b/backend/tests/test_libraries_api.py
@@ -41,15 +41,15 @@ class LibrariesAuthorizationTest(unittest.TestCase):
             embedding_model_name="test-model",
         )
         vector_store.update_library_metadata(
-            LibraryIndexMetadata(library_id="users/1", library_type="user", library_name="Mine")
+            LibraryIndexMetadata(library_id="u1", library_type="user", library_name="Mine")
         )
         vector_store.update_library_metadata(
-            LibraryIndexMetadata(library_id="users/2", library_type="user", library_name="Someone Else's")
+            LibraryIndexMetadata(library_id="u2", library_type="user", library_name="Someone Else's")
         )
         app.state.vector_store = vector_store
 
-        RegistrationService(s.registrations_path).register("users/1", "Mine", 1, "u")
-        RegistrationService(s.registrations_path).register("users/2", "Someone Else's", 2, "other")
+        RegistrationService(s.registrations_path).register("u1", "Mine", 1, "u")
+        RegistrationService(s.registrations_path).register("u2", "Someone Else's", 2, "other")
 
     def tearDown(self):
         app.dependency_overrides.clear()
@@ -65,33 +65,33 @@ class LibrariesAuthorizationTest(unittest.TestCase):
         r = self.client.get("/api/libraries")
         self.assertEqual(r.status_code, 200)
         ids = [lib["library_id"] for lib in r.json()]
-        self.assertEqual(ids, ["users/1"])
+        self.assertEqual(ids, ["u1"])
 
     def test_list_unrestricted_when_no_identity(self):
         self._set_identity(None)
         r = self.client.get("/api/libraries")
         self.assertEqual(r.status_code, 200)
         ids = {lib["library_id"] for lib in r.json()}
-        self.assertEqual(ids, {"users/1", "users/2"})
+        self.assertEqual(ids, {"u1", "u2"})
 
     def test_delete_index_outside_targets_is_403(self):
         self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
-        r = self.client.delete("/api/libraries/users/2/index")
+        r = self.client.delete("/api/libraries/u2/index")
         self.assertEqual(r.status_code, 403)
 
     def test_delete_index_within_targets_succeeds(self):
         self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
-        r = self.client.delete("/api/libraries/users/1/index")
+        r = self.client.delete("/api/libraries/u1/index")
         self.assertEqual(r.status_code, 200)
 
     def test_sync_deletions_outside_targets_is_403(self):
         self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
-        r = self.client.post("/api/libraries/users/2/sync-deletions", json={"current_item_keys": []})
+        r = self.client.post("/api/libraries/u2/sync-deletions", json={"current_item_keys": []})
         self.assertEqual(r.status_code, 403)
 
     def test_clear_item_chunks_outside_targets_is_403(self):
         self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
-        r = self.client.delete("/api/libraries/users/2/items/ITEM1/chunks")
+        r = self.client.delete("/api/libraries/u2/items/ITEM1/chunks")
         self.assertEqual(r.status_code, 403)
 
 

--- a/backend/tests/test_libraries_api.py
+++ b/backend/tests/test_libraries_api.py
@@ -1,0 +1,99 @@
+"""Endpoint tests for backend.api.libraries authorization:
+- GET /api/libraries is filtered to the caller's own targets
+- DELETE .../index, POST .../sync-deletions, DELETE .../items/{key}/chunks
+  all 403 for a library outside the caller's targets
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.db.vector_store import VectorStore
+from backend.models.library import LibraryIndexMetadata
+from backend.services.registration_service import RegistrationService
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+import backend.dependencies as dependencies
+
+
+class LibrariesAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        # `data_path` is only used to *derive* other paths at Settings construction
+        # time (see set_derived_paths); mutating it post-construction does not
+        # move already-resolved paths like registrations_path. Without this, the
+        # RegistrationService calls below would write into the real project's
+        # data/system/registrations.json instead of the temp sandbox.
+        s.registrations_path = Path(self.tmp.name) / "system" / "registrations.json"
+        s.testing = True
+        self.client = TestClient(app)
+
+        vector_store = VectorStore(
+            storage_path=Path(self.tmp.name) / "qdrant",
+            embedding_dim=8,
+            embedding_model_name="test-model",
+        )
+        vector_store.update_library_metadata(
+            LibraryIndexMetadata(library_id="users/1", library_type="user", library_name="Mine")
+        )
+        vector_store.update_library_metadata(
+            LibraryIndexMetadata(library_id="users/2", library_type="user", library_name="Someone Else's")
+        )
+        app.state.vector_store = vector_store
+
+        RegistrationService(s.registrations_path).register("users/1", "Mine", 1, "u")
+        RegistrationService(s.registrations_path).register("users/2", "Someone Else's", 2, "other")
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def _set_identity(self, identity):
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def test_list_filters_to_own_targets(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 200)
+        ids = [lib["library_id"] for lib in r.json()]
+        self.assertEqual(ids, ["users/1"])
+
+    def test_list_unrestricted_when_no_identity(self):
+        self._set_identity(None)
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 200)
+        ids = {lib["library_id"] for lib in r.json()}
+        self.assertEqual(ids, {"users/1", "users/2"})
+
+    def test_delete_index_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.delete("/api/libraries/users/2/index")
+        self.assertEqual(r.status_code, 403)
+
+    def test_delete_index_within_targets_succeeds(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.delete("/api/libraries/users/1/index")
+        self.assertEqual(r.status_code, 200)
+
+    def test_sync_deletions_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post("/api/libraries/users/2/sync-deletions", json={"current_item_keys": []})
+        self.assertEqual(r.status_code, 403)
+
+    def test_clear_item_chunks_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.delete("/api/libraries/users/2/items/ITEM1/chunks")
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_main_auth_middleware.py
+++ b/backend/tests/test_main_auth_middleware.py
@@ -61,14 +61,6 @@ class AuthMiddlewareTest(unittest.TestCase):
             r = self.client.get("/api/libraries", headers={"X-Zotero-API-Key": "KEY"})
         self.assertEqual(r.status_code, 200)
 
-    def test_remote_with_legacy_shared_key_still_works(self):
-        s = get_settings()
-        s.api_host = "rag.example.com"
-        s.authorized_group_id = 999
-        s.api_key = "SHARED"
-        r = self.client.get("/api/libraries", headers={"X-API-Key": "SHARED"})
-        self.assertEqual(r.status_code, 200)
-
     def test_health_and_version_exempt_even_on_remote_host(self):
         s = get_settings()
         s.api_host = "rag.example.com"

--- a/backend/tests/test_main_auth_middleware.py
+++ b/backend/tests/test_main_auth_middleware.py
@@ -1,0 +1,81 @@
+"""End-to-end tests for the api_key_middleware wiring in backend.main.
+
+Uses the real app (TestClient(app)) and an already-existing, unmodified
+route (GET /api/libraries) purely to exercise the middleware's status-code
+behavior. Response *content* filtering is covered later once
+backend/api/libraries.py itself is wired (see test_libraries_api.py, a
+later task not yours)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.zotero_identity import reset_identity_cache
+from backend.zotero.key_validator import KeyValidation
+
+
+class AuthMiddlewareTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        # GET /api/libraries (the unmodified route used below purely to probe
+        # middleware status codes) depends on app.state.vector_store, which is
+        # only populated by the app's lifespan — and TestClient(app) without a
+        # `with` block never runs lifespan. Stub it directly so requests that
+        # are meant to reach the handler don't 500 for this unrelated reason.
+        app.state.vector_store = MagicMock()
+        app.state.vector_store.get_all_library_metadata.return_value = []
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        del app.state.vector_store
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def test_loopback_reaches_handler_without_any_key(self):
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 200)
+
+    def test_remote_without_any_key_is_401(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_with_gated_zotero_key_reaches_handler(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1", "groups/999"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/api/libraries", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_remote_with_legacy_shared_key_still_works(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/api/libraries", headers={"X-API-Key": "SHARED"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_health_and_version_exempt_even_on_remote_host(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        self.assertEqual(self.client.get("/health").status_code, 200)
+        self.assertEqual(self.client.get("/api/version").status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_query_api.py
+++ b/backend/tests/test_query_api.py
@@ -41,19 +41,19 @@ class QueryAuthorizationTest(unittest.TestCase):
 
     def test_loopback_query_with_no_identity_is_unrestricted(self):
         self._set_identity(None)
-        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/1"]})
+        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["u1"]})
         self.assertNotEqual(r.status_code, 403)
 
     def test_query_outside_targets_is_403(self):
         identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
         self._set_identity(identity)
-        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/2"]})
+        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["u2"]})
         self.assertEqual(r.status_code, 403)
 
     def test_query_within_targets_is_not_403(self):
         identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
         self._set_identity(identity)
-        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/1"]})
+        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["u1"]})
         self.assertNotEqual(r.status_code, 403)
 
     def test_query_with_one_target_outside_is_403_even_if_another_is_inside(self):
@@ -61,7 +61,7 @@ class QueryAuthorizationTest(unittest.TestCase):
         self._set_identity(identity)
         r = self.client.post(
             "/api/query",
-            json={"question": "q?", "library_ids": ["users/1", "users/2"]},
+            json={"question": "q?", "library_ids": ["u1", "u2"]},
         )
         self.assertEqual(r.status_code, 403)
 

--- a/backend/tests/test_query_api.py
+++ b/backend/tests/test_query_api.py
@@ -1,0 +1,70 @@
+"""Endpoint tests for POST /api/query's per-library authorization."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+import backend.dependencies as dependencies
+
+
+class QueryAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        s.testing = True
+        # Enter the TestClient as a context manager (not just construct it) so
+        # that FastAPI's `lifespan` runs and populates app.state.vector_store —
+        # otherwise get_vector_store() raises AttributeError before the
+        # handler body (and its access-gate check) ever runs.
+        self.client = TestClient(app).__enter__()
+
+    def tearDown(self):
+        self.client.__exit__(None, None, None)
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+        app.dependency_overrides.clear()
+
+    def _set_identity(self, identity):
+        """Bypass the middleware/network round-trip: override the
+        get_zotero_identity dependency directly, matching how FastAPI's own
+        dependency_overrides mechanism is meant to be used in tests."""
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def test_loopback_query_with_no_identity_is_unrestricted(self):
+        self._set_identity(None)
+        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/1"]})
+        self.assertNotEqual(r.status_code, 403)
+
+    def test_query_outside_targets_is_403(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self._set_identity(identity)
+        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/2"]})
+        self.assertEqual(r.status_code, 403)
+
+    def test_query_within_targets_is_not_403(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self._set_identity(identity)
+        r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/1"]})
+        self.assertNotEqual(r.status_code, 403)
+
+    def test_query_with_one_target_outside_is_403_even_if_another_is_inside(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self._set_identity(identity)
+        r = self.client.post(
+            "/api/query",
+            json={"question": "q?", "library_ids": ["users/1", "users/2"]},
+        )
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_reconcile_count.py
+++ b/backend/tests/test_reconcile_count.py
@@ -83,7 +83,7 @@ class TestClearItemChunksCascadesDedup(unittest.TestCase):
         vs = MagicMock()
         vs.delete_item_chunks.return_value = 4
 
-        result = clear_item_chunks("6297749", "ITEM001", vector_store=vs)
+        result = clear_item_chunks("6297749", "ITEM001", identity=None, vector_store=vs)
 
         vs.delete_item_chunks.assert_called_once_with("6297749", "ITEM001")
         vs.delete_item_deduplication_records.assert_called_once_with("6297749", "ITEM001")

--- a/backend/tests/test_reconcile_count.py
+++ b/backend/tests/test_reconcile_count.py
@@ -38,7 +38,7 @@ class TestReconcileCountGuard(unittest.TestCase):
         vs.count_indexed_items.return_value = 195  # implausibly low
 
         with self.assertRaises(HTTPException) as ctx:
-            reconcile_library_count("2829873", vector_store=vs)
+            reconcile_library_count("2829873", identity=None, vector_store=vs)
 
         self.assertEqual(ctx.exception.status_code, 409)
         # The counter must not have been overwritten.
@@ -52,7 +52,7 @@ class TestReconcileCountGuard(unittest.TestCase):
         vs.get_library_metadata.return_value = meta
         vs.count_indexed_items.return_value = 5900  # small, legitimate drop
 
-        result = reconcile_library_count("2829873", vector_store=vs)
+        result = reconcile_library_count("2829873", identity=None, vector_store=vs)
 
         vs.update_library_metadata.assert_called_once()
         self.assertEqual(result.total_items_indexed, 5900)
@@ -64,7 +64,7 @@ class TestReconcileCountGuard(unittest.TestCase):
         vs.get_library_metadata.return_value = meta
         vs.count_indexed_items.return_value = 3
 
-        result = reconcile_library_count("2829873", vector_store=vs)
+        result = reconcile_library_count("2829873", identity=None, vector_store=vs)
 
         vs.update_library_metadata.assert_called_once()
         self.assertEqual(result.total_items_indexed, 3)

--- a/backend/tests/test_registration_api.py
+++ b/backend/tests/test_registration_api.py
@@ -1,0 +1,69 @@
+"""Endpoint tests for backend.api.registration authorization:
+- GET /api/registrations is filtered to the caller's own accessible libraries
+- POST /api/register 403s when the caller can't access the target library_id
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.registration_service import RegistrationService
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+import backend.dependencies as dependencies
+
+
+class RegistrationAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        self.client = TestClient(app)
+        RegistrationService(s.registrations_path).register("u1", "Mine", 1, "u")
+        RegistrationService(s.registrations_path).register("u2", "Someone Else's", 2, "other")
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def _set_identity(self, identity):
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def test_get_registrations_filters_to_own_targets(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.get("/api/registrations")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(set(r.json().keys()), {"u1"})
+
+    def test_get_registrations_unrestricted_when_no_identity(self):
+        self._set_identity(None)
+        r = self.client.get("/api/registrations")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(set(r.json().keys()), {"u1", "u2"})
+
+    def test_register_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/register",
+            json={"library_id": "u2", "library_name": "Attempt", "user_id": 1, "username": "u"},
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_register_within_targets_succeeds(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/register",
+            json={"library_id": "u1", "library_name": "Mine Updated", "user_id": 1, "username": "u"},
+        )
+        self.assertEqual(r.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_registration_api.py
+++ b/backend/tests/test_registration_api.py
@@ -23,6 +23,7 @@ class RegistrationAuthorizationTest(unittest.TestCase):
         reset_identity_cache()
         s = get_settings()
         s.data_path = Path(self.tmp.name)
+        s.registrations_path = Path(self.tmp.name) / "system" / "registrations.json"
         self.client = TestClient(app)
         RegistrationService(s.registrations_path).register("u1", "Mine", 1, "u")
         RegistrationService(s.registrations_path).register("u2", "Someone Else's", 2, "other")

--- a/backend/tests/test_registration_api.py
+++ b/backend/tests/test_registration_api.py
@@ -65,6 +65,26 @@ class RegistrationAuthorizationTest(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200)
 
+    def test_register_ignores_body_user_id_uses_identity(self):
+        # setUp already registered user_id=1/"u" for library "u1"; RegistrationService.register()
+        # dedups new entries by user_id, so this identity must use a user_id not already present
+        # on "u1" for the new-entry path (and thus the body-vs-identity divergence) to be exercised.
+        self._set_identity(ZoteroIdentity(user_id=7, username="real_owner", targets=["users/1"]))
+        r = self.client.post(
+            "/api/register",
+            json={"library_id": "u1", "library_name": "Mine", "user_id": 999999, "username": "spoofed_victim"},
+        )
+        self.assertEqual(r.status_code, 200)
+        # Fetch back via the (already-fixed, identity-filtered) GET /api/registrations
+        r2 = self.client.get("/api/registrations")
+        entry = r2.json()["u1"]
+        usernames = {u["username"] for u in entry["users"]}
+        user_ids = {u["user_id"] for u in entry["users"]}
+        self.assertIn("real_owner", usernames)
+        self.assertNotIn("spoofed_victim", usernames)
+        self.assertIn(7, user_ids)
+        self.assertNotIn(999999, user_ids)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_resolve_zotero_identity.py
+++ b/backend/tests/test_resolve_zotero_identity.py
@@ -1,0 +1,115 @@
+"""Unit tests for backend.dependencies.resolve_zotero_identity, tested in
+isolation via a throwaway FastAPI app (not backend.main.app)."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from backend.config.settings import get_settings, reset_settings
+from backend.dependencies import resolve_zotero_identity
+from backend.services.zotero_identity import reset_identity_cache
+from backend.zotero.key_validator import KeyValidation
+
+
+def _make_probe_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(identity=Depends(resolve_zotero_identity)):
+        if identity is None:
+            return {"identity": None}
+        return {"user_id": identity.user_id, "targets": identity.targets}
+
+    return app
+
+
+class ResolveZoteroIdentityTest(unittest.TestCase):
+    def setUp(self):
+        reset_settings()
+        reset_identity_cache()
+        self.client = TestClient(_make_probe_app())
+
+    def tearDown(self):
+        reset_settings()
+        reset_identity_cache()
+
+    def test_loopback_skips_auth_entirely(self):
+        get_settings().api_host = "localhost"
+        r = self.client.get("/probe")
+        self.assertEqual(r.status_code, 200)
+        self.assertIsNone(r.json()["identity"])
+
+    def test_remote_missing_key_rejected(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/probe")
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_valid_gated_key_returns_identity(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1", "groups/999"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["user_id"], 1)
+
+    def test_remote_valid_but_ungated_key_rejected(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 403)
+
+    def test_remote_revoked_key_rejected_with_401(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(None, None, read_only=False, reason="revoked", transient=False)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_zotero_unreachable_no_cache_returns_503(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(None, None, read_only=False, reason="down", transient=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 503)
+
+    def test_legacy_shared_key_accepted_as_transitional_fallback(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/probe", headers={"X-API-Key": "SHARED"})
+        self.assertEqual(r.status_code, 200)
+        self.assertIsNone(r.json()["identity"])
+
+    def test_legacy_key_via_query_param_accepted(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/probe?api_key=SHARED")
+        self.assertEqual(r.status_code, 200)
+
+    def test_wrong_legacy_key_rejected(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/probe", headers={"X-API-Key": "WRONG"})
+        self.assertEqual(r.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_resolve_zotero_identity.py
+++ b/backend/tests/test_resolve_zotero_identity.py
@@ -48,6 +48,13 @@ class ResolveZoteroIdentityTest(unittest.TestCase):
         r = self.client.get("/probe")
         self.assertEqual(r.status_code, 401)
 
+    def test_legacy_shared_key_no_longer_accepted(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/probe", headers={"X-API-Key": "SHARED"})
+        self.assertEqual(r.status_code, 401)
+
     def test_remote_valid_gated_key_returns_identity(self):
         s = get_settings()
         s.api_host = "rag.example.com"
@@ -84,31 +91,6 @@ class ResolveZoteroIdentityTest(unittest.TestCase):
         with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
             r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
         self.assertEqual(r.status_code, 503)
-
-    def test_legacy_shared_key_accepted_as_transitional_fallback(self):
-        s = get_settings()
-        s.api_host = "rag.example.com"
-        s.authorized_group_id = 999
-        s.api_key = "SHARED"
-        r = self.client.get("/probe", headers={"X-API-Key": "SHARED"})
-        self.assertEqual(r.status_code, 200)
-        self.assertIsNone(r.json()["identity"])
-
-    def test_legacy_key_via_query_param_accepted(self):
-        s = get_settings()
-        s.api_host = "rag.example.com"
-        s.authorized_group_id = 999
-        s.api_key = "SHARED"
-        r = self.client.get("/probe?api_key=SHARED")
-        self.assertEqual(r.status_code, 200)
-
-    def test_wrong_legacy_key_rejected(self):
-        s = get_settings()
-        s.api_host = "rag.example.com"
-        s.authorized_group_id = 999
-        s.api_key = "SHARED"
-        r = self.client.get("/probe", headers={"X-API-Key": "WRONG"})
-        self.assertEqual(r.status_code, 401)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_settings_access_gate.py
+++ b/backend/tests/test_settings_access_gate.py
@@ -1,0 +1,35 @@
+"""Unit tests for the Part 2 access-gate settings fields."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from backend.config.settings import Settings
+
+
+class AccessGateSettingsTest(unittest.TestCase):
+    def test_authorized_group_id_defaults_none(self):
+        s = Settings()
+        self.assertIsNone(s.authorized_group_id)
+
+    def test_authorized_user_ids_defaults_empty(self):
+        s = Settings()
+        self.assertEqual(s.authorized_user_ids, [])
+
+    def test_authorized_group_id_from_env(self):
+        with patch.dict(os.environ, {"AUTHORIZED_GROUP_ID": "998877"}):
+            s = Settings()
+        self.assertEqual(s.authorized_group_id, 998877)
+
+    def test_authorized_user_ids_parses_comma_separated_env(self):
+        with patch.dict(os.environ, {"AUTHORIZED_USER_IDS": "123, 456"}):
+            s = Settings()
+        self.assertEqual(s.authorized_user_ids, [123, 456])
+
+    def test_authorized_user_ids_accepts_list(self):
+        s = Settings(authorized_user_ids=[1, 2])
+        self.assertEqual(s.authorized_user_ids, [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_upload_and_batching.py
+++ b/backend/tests/test_upload_and_batching.py
@@ -156,7 +156,6 @@ class TestUploadTimeoutWarning(unittest.TestCase):
         with (
             patch("backend.api.document_upload.make_embedding_service") as mock_emb,
             patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
-            patch("backend.api.document_upload._check_registration"),
         ):
             mock_proc = MagicMock()
             mock_proc_cls.return_value = mock_proc
@@ -185,7 +184,6 @@ class TestUploadTimeoutWarning(unittest.TestCase):
         with (
             patch("backend.api.document_upload.make_embedding_service"),
             patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
-            patch("backend.api.document_upload._check_registration"),
         ):
             mock_proc = MagicMock()
             mock_proc_cls.return_value = mock_proc
@@ -208,7 +206,6 @@ class TestUploadTimeoutWarning(unittest.TestCase):
         with (
             patch("backend.api.document_upload.make_embedding_service"),
             patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
-            patch("backend.api.document_upload._check_registration"),
         ):
             mock_proc = MagicMock()
             mock_proc_cls.return_value = mock_proc
@@ -277,7 +274,6 @@ class TestOrphanedDedupSelfHeal(unittest.TestCase):
         with (
             patch("backend.api.document_upload.make_embedding_service") as mock_emb_factory,
             patch("backend.api.document_upload.DocumentProcessor") as mock_proc_cls,
-            patch("backend.api.document_upload._check_registration"),
         ):
             mock_emb = MagicMock()
             mock_emb.rate_limit_retries = 0

--- a/backend/tests/test_zotero_identity.py
+++ b/backend/tests/test_zotero_identity.py
@@ -1,0 +1,72 @@
+"""Unit tests for backend.services.zotero_identity (the Part 1.3 validation cache)."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from backend.services.zotero_identity import ZoteroIdentity, ZoteroIdentityCache
+from backend.zotero.key_validator import KeyValidation
+
+
+class ZoteroIdentityCacheTest(unittest.IsolatedAsyncioTestCase):
+    async def test_caches_successful_validation(self):
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        mock_validate = AsyncMock(return_value=validation)
+        cache = ZoteroIdentityCache(ttl_seconds=60)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, validation)
+        self.assertIs(second, validation)
+        mock_validate.assert_awaited_once()
+
+    async def test_expired_entry_revalidates(self):
+        old = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        new = KeyValidation(user_id=1, username="u", targets=["users/1", "groups/2"], read_only=True)
+        mock_validate = AsyncMock(side_effect=[old, new])
+        cache = ZoteroIdentityCache(ttl_seconds=0)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, old)
+        self.assertIs(second, new)
+        self.assertEqual(mock_validate.await_count, 2)
+
+    async def test_transient_failure_serves_stale_cache(self):
+        good = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        transient_failure = KeyValidation(None, None, read_only=False, reason="down", transient=True)
+        mock_validate = AsyncMock(side_effect=[good, transient_failure])
+        cache = ZoteroIdentityCache(ttl_seconds=0)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, good)
+        self.assertIs(second, good)  # stale cache served instead of the transient failure
+
+    async def test_hard_failure_not_masked_by_stale_cache(self):
+        good = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        revoked = KeyValidation(None, None, read_only=False, reason="revoked", transient=False)
+        mock_validate = AsyncMock(side_effect=[good, revoked])
+        cache = ZoteroIdentityCache(ttl_seconds=0)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, good)
+        self.assertIs(second, revoked)  # a hard failure always overwrites the cache
+
+    async def test_no_cache_entry_and_transient_failure_propagates(self):
+        transient_failure = KeyValidation(None, None, read_only=False, reason="down", transient=True)
+        mock_validate = AsyncMock(return_value=transient_failure)
+        cache = ZoteroIdentityCache(ttl_seconds=60)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            result = await cache.resolve("KEY")
+        self.assertIs(result, transient_failure)
+
+    def test_zotero_identity_is_a_plain_value_object(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self.assertEqual(identity.user_id, 1)
+        self.assertEqual(identity.username, "u")
+        self.assertEqual(identity.targets, ["users/1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,8 +65,6 @@ services:
       # Keep at 1: multiple workers each have their own in-memory task store and
       # break async task polling (issue #30). asyncio handles I/O concurrency fine.
       UVICORN_WORKERS: ${UVICORN_WORKERS:-1}
-      # set a secret api key for a real deployment!
-      API_KEY: ${API_KEY:-}
       DATA_PATH: /data
       # Path to public libraries config inside the container (e.g. /data/public-libraries.json)
       PUBLIC_LIBRARIES_CONFIG: ${PUBLIC_LIBRARIES_CONFIG:-}

--- a/docs/history/implementation/master.md
+++ b/docs/history/implementation/master.md
@@ -693,3 +693,20 @@ npm run plugin:build
 - Source: `plugin/src/`
 - Build output: `plugin/build/` (temporary)
 - XPI archive: `plugin/dist/zotero-rag-{version}.xpi`
+
+## Zotero-Key Authentication Migration (2026-07)
+
+Replaced the single shared `X-API-Key` secret with per-user Zotero.org authentication, closing an
+IDOR where any user with the shared key could read/delete any other user's library.
+
+- **Backend (Parts 1–2):** identity-derived authorization — every request's Zotero API key
+  resolves to `(user_id, username, targets)` via `api.zotero.org`, cached with a TTL; every
+  library-scoped endpoint checks `library_id ∈ targets`. A Part 2 access gate (group membership
+  and/or an explicit user-id allowlist) controls who may use the instance at all. See
+  `docs/history/plan-zotero-key-auth.md`.
+- **Plugin + cutover (Part 3 + Part 5):** the plugin now sends `X-Zotero-API-Key` instead of the
+  shared secret; a 3-step setup wizard (Server → Zotero identity → Service API keys) obtains and
+  validates the key via the new `GET /api/auth/whoami`; auto-indexing collapsed to a single on/off
+  toggle reusing that same key. The backend's transitional shared-secret fallback was removed in
+  the same change (no staged migration window — single-operator deployment). See
+  `docs/superpowers/specs/2026-07-06-zotero-key-auth-plugin-wizard-design.md`.

--- a/docs/history/plan-zotero-key-auth.md
+++ b/docs/history/plan-zotero-key-auth.md
@@ -1,0 +1,295 @@
+# Plan: Replace the shared API key with per-user Zotero.org authentication
+
+## Problem this fixes
+
+Today every `/api/*` request is authenticated against a **single global shared secret**
+(`settings.api_key`, compared in `backend/main.py:158-168`). On the documented multi-tenant
+deployment (`rag.panya.de`), every user configures the plugin with the *same* key, and there is
+**no per-caller authorization** on the read/delete paths:
+
+- `POST /api/query` returns verbatim chunk content for any `library_ids` in the body
+  (`backend/api/query.py:58`).
+- `GET /api/libraries` enumerates **all** libraries + registered usernames/user IDs
+  (`backend/api/libraries.py:80`).
+- `DELETE /api/libraries/{id}/index` (and sync-deletions, item-chunk delete, batch metadata)
+  wipes any library (`backend/api/libraries.py:152`).
+
+Any legitimate user can therefore read or destroy any other user's library. The ownership
+primitive exists (`RegistrationService`) but is wired only into the write/index paths, and even
+there the `user_id` is self-asserted from the request body (`document_upload.py:980`).
+
+## Core idea
+
+Stop using a shared secret as the credential. Make the credential the user's own **read-only
+Zotero API key**. The backend already has everything needed to turn that key into a trustworthy
+identity: `backend/zotero/key_validator.py::validate_key()` calls
+`GET https://api.zotero.org/keys/<key>` and returns:
+
+```
+KeyValidation(user_id, username, targets=["users/<id>", "groups/<id>", ...], read_only, ...)
+```
+
+`targets` is exactly the set of libraries that key is allowed to read. So:
+
+- **Authentication** = "the key resolves to a real Zotero identity."
+- **Authorization** = "every `library_id` in the request is in that key's `targets`."
+
+This binds every operation to Zotero's own permission model and closes the IDOR: you cannot name
+a library your key cannot read. It also removes the need to build and maintain our own access
+registry — we lean entirely on zotero.org.
+
+---
+
+## Part 1 — Backend: identity-derived authorization
+
+### 1.1 Auth dependency
+
+Replace the binary middleware check with a FastAPI dependency (`require_zotero_identity`) that:
+
+1. Reads the Zotero key from a dedicated header, `X-Zotero-API-Key` (keep it distinct from the
+   LLM/embedding provider keys already sent in `getAuthHeaders()`).
+2. Validates it via a **cached** wrapper around `validate_key()` (see 1.3).
+3. Rejects with 401 if the key is missing/invalid; 503 if zotero.org is unreachable and there is
+   no cached result.
+4. Applies the **access gate** (Part 2). Rejects with 403 if the identity is not authorized.
+5. Attaches `ZoteroIdentity(user_id, username, targets)` to `request.state` for handlers.
+
+The existing global `api_key` middleware is removed for `/api/*` (kept only for the optional
+local/self-host mode, Part 4).
+
+### 1.2 Per-handler enforcement (`target ∈ identity.targets`)
+
+Add a small helper `assert_can_access(identity, library_id)` and apply it at every point a
+library is named:
+
+| Endpoint | Enforcement |
+| --- | --- |
+| `POST /api/query` | every `library_ids[i] ∈ targets`, else 403 |
+| `GET /api/libraries` | **filter** the response to `targets` (each user sees only their own) |
+| `DELETE /api/libraries/{id}/index` | `id ∈ targets` |
+| `POST .../sync-deletions`, item-chunk delete, batch-metadata | `library_id ∈ targets` |
+| upload/index endpoints (`document_upload.py`) | `library_id ∈ targets`; derive `user_id` from the **validated key**, never from the request body |
+
+This makes `RegistrationService` redundant for authorization. Keep it, if at all, only as a
+display/bookkeeping record populated from the validated identity — not as a security boundary.
+
+### 1.3 Validation cache
+
+Per-request calls to zotero.org add latency and a hard dependency. Add an in-memory TTL cache
+keyed by `fingerprint(key)` (reuse `autoindex_key_store.fingerprint`) → `KeyValidation`, TTL
+~10 min. On a transient zotero.org failure (`KeyValidation.transient`), serve the cached value if
+present; otherwise 503. Group enumeration (`/users/<id>/groups`) is part of the cached result, so
+it is paid once per key per TTL window, not per request.
+
+### 1.4 Remove self-asserted identity
+
+Delete `user_id` from `AbstractIndexRequest` and the multipart metadata parsing
+(`document_upload.py:239, 980`). Everywhere it was read from the body, read
+`request.state.zotero_identity.user_id` instead.
+
+---
+
+## Part 2 — The access gate: which Zotero users may use the server
+
+Any Zotero user has a valid key, so identity alone is not authorization to *use this instance*.
+The key payload exposes only `userID` and `username` — no email or org affiliation — so an email
+domain rule is impossible. Options, best to worst:
+
+### Decision: Option A, with Option B as a fallback/override
+
+### Option A: membership in a designated "gatekeeper" Zotero group
+
+- The operator creates a **private Zotero group** (e.g. "RAG Users") and sets
+  `AUTHORIZED_GROUP_ID=<id>` in the deploy env.
+- A user is authorized **iff** their validated key's `targets` include `groups/<AUTHORIZED_GROUP_ID>`
+  — i.e. they are a member of that group and their key grants group read.
+- **Self-service membership**: the operator invites/approves/removes members in Zotero's own group
+  admin UI. No server-side list, no redeploy to grant or revoke access. Revocation takes effect on
+  the next cache-TTL expiry.
+- The group needs no content; membership is the only signal.
+- **Cost**: the operator runs one Zotero group; each user accepts the invite and creates a key with
+  "all groups — read" (the validator already enumerates these). Onboarding is one extra click.
+
+### Option B: explicit `user_id` allowlist
+
+- `AUTHORIZED_USER_IDS` env var or a small JSON file the server reads.
+- Allowlist by **`user_id`** (stable), not `username` (user-changeable on zotero.org).
+- Simple and explicit, but every add/remove is a manual ops action. Good as a fallback or for a
+  tiny fixed team, and as an admin override.
+
+### Option C: one-time invite tokens
+
+- Operator issues codes; first successful auth with a code binds `user_id` into a persisted
+  allowlist. Re-introduces a (small) server-side registry — the thing we are trying to avoid.
+  Not recommended.
+
+### Decided
+
+Primary **Option A**, with **Option B as an optional OR-override** (authorized if in the group
+*or* in the explicit `user_id` allowlist). **Fail closed**: if neither `AUTHORIZED_GROUP_ID` nor
+`AUTHORIZED_USER_IDS` is configured, the server refuses to start in remote mode, so no one can
+accidentally run a wide-open instance.
+
+---
+
+## Part 3 — Plugin: mandatory key + setup wizard
+
+### 3.1 Send the key
+
+- Add a `zoteroApiKey` pref; in `getAuthHeaders()` (`plugin/src/zotero-rag.js:201`) send it as
+  `X-Zotero-API-Key`. Drop the shared `X-API-Key` once migration completes (Part 5).
+
+### 3.2 Setup wizard (first run, or when key is missing/invalid/ungated)
+
+1. Explain why a Zotero key is required (identity + access control).
+2. **"Create key on zotero.org"** button → open `https://www.zotero.org/settings/keys/new` in the
+   external browser. Instruct: *Personal library — read only*; and *All groups — read only*
+   (needed for the group gate). (Verify whether the new-key page accepts prefill query params such
+   as `name`/`library_access`; if so, deep-link with them to reduce clicks.)
+3. User pastes the key back into the wizard.
+4. Plugin calls `POST /api/auth/validate` (new lightweight endpoint that runs the same validation +
+   gate and returns `{authorized, user_id, username, targets, gate_reason?}` — never echoes the
+   key).
+5. On success: store the key, show which libraries are accessible. On **gate failure with the group
+   option**: show a "Request access — join the RAG Users group" message with a deep link to the
+   group's join page.
+6. Optional unification: offer *"also enable server-side automatic indexing"*, which simply submits
+   the **same** key to the existing `POST /api/autoindex/keys`. One key, both features.
+
+### 3.3 Reference touch points
+
+- Key/header logic: `plugin/src/zotero-rag.js:169-217`.
+- Preferences UI: `plugin/src/preferences.xhtml` / `preferences.js`.
+- Existing auto-index submission UI already exists — reuse its validation UX for the wizard.
+
+---
+
+## Part 4 — Keeping purely local / single-user setups (explicitly out of scope as a priority)
+
+### Decision
+
+**Loopback-bound setups skip Zotero-key authentication (and the Part 2 gate) completely.**
+Everywhere else, Zotero.org authentication is mandatory — there is no opt-in shared-key fallback
+for remote deployments (Option 4.2 below is rejected, not just deprioritized). This is Option 4.1,
+formalized as the only supported non-remote mode; see rationale and guardrails below.
+
+This change makes zotero.org sync **mandatory for the shared/remote mode**: a purely local Zotero
+(local API only, no account, no sync) has no zotero.org key and therefore no identity and no way to
+pass the gate. That is acceptable for the primary use case, but here are the ways to keep supporting
+local-only users and their costs, so the decision is explicit.
+
+**Why the IDOR does not actually affect a true single-user deploy:** the vulnerability requires
+*multiple* users sharing one key on one instance. A single self-hoster using only their own
+libraries has no second tenant to attack. So local support is about *not breaking* those users, not
+about them needing the new gate.
+
+### Option 4.1 (decided): loopback-bound, no-auth local mode
+
+- The code already special-cases `api_host ∈ {localhost, 127.0.0.1}` (`document_upload.py:254`).
+  Extend that: when bound to loopback, **skip Zotero-key auth and the gate entirely**. Single
+  trusted local user, port not exposed, IDOR irrelevant.
+- **Guardrail**: refuse to start no-auth mode on a non-loopback host, so an operator cannot expose
+  local mode on `0.0.0.0`.
+- **Cost**: near-zero. Two code paths (remote hardened vs. local trusted), both already implied by
+  the existing localhost branch.
+
+### Option 4.2: keep the legacy shared-key mode as an opt-in for self-hosters (rejected)
+
+- A single user self-hosting for themselves sets `API_KEY` and only ever touches their own
+  libraries. Safe **as long as the key is never shared across users**.
+- **Cost**: we retain the vulnerable-by-design code path and must document loudly "single-tenant
+  only." Two auth systems to maintain and test.
+- **Rejected**: the decision above removes this as an option for non-loopback deployments entirely,
+  not just after a migration window — see Part 5, which now has no long-term legacy fallback.
+
+### Option 4.3: Zotero-key identity without the gate (rejected)
+
+- Use Zotero-key auth (closes the IDOR) but leave `AUTHORIZED_*` unset for a small trusted group.
+- **Cost**: still requires Zotero accounts (so not truly "local"), and is open to anyone with the
+  URL if exposed — only safe on a private network. Conflicts with the fail-closed default, so it
+  would need an explicit `ALLOW_ANY_ZOTERO_USER=true` opt-in.
+- **Rejected**: "zotero.org auth is mandatory everywhere except loopback" leaves no room for a
+  gate-less-but-remote mode.
+
+### Consequence
+
+Exactly one hardened remote path (Zotero-key + Part 2 gate) and one clearly-scoped local path
+(loopback, no auth, one user), consistent with today's localhost special-casing. Truly local,
+*multi-user*, no-zotero.org setups are an accepted non-goal.
+
+---
+
+## Part 5 — Migration / rollout
+
+Given the Part 4 decision (no long-term legacy fallback for remote deployments), the transitional
+phase exists only to avoid breaking already-deployed plugins during rollout — it is not a
+permanent alternative mode.
+
+1. Ship the plugin update with the setup wizard and `X-Zotero-API-Key` first.
+2. Backend transitional phase (short window, security fix — days not months): accept **either** a
+   valid Zotero key **or** the legacy `API_KEY`, so un-upgraded plugins keep working while users
+   migrate. Log usage of the legacy path so the operator can see when it's safe to cut over.
+3. Announce the change and the cutover date to all known users (e.g. via the plugin's update
+   notes and/or the existing registered-user list).
+4. Flip the server to Zotero-key-only for non-loopback hosts (remove the legacy `api_key`
+   middleware for `/api/*` entirely; loopback keeps the no-auth local mode from Part 4).
+
+---
+
+## Post-fix threat model
+
+- A user can read/delete only libraries their Zotero key can read → **IDOR closed**.
+- Only group members (or allowlisted `user_id`s) can use the instance at all → arbitrary Zotero
+  users blocked; **fail-closed** default prevents an accidentally-open instance.
+- Live query auth never persists the user's key (validate + in-memory cache only). The auto-index
+  store continues to encrypt keys at rest (Fernet) for cron.
+- Compromise of one user's key exposes only that user's libraries, not the whole instance (unlike
+  the shared key today).
+
+## Decisions log
+
+- **Part 2 (access gate)**: Option A (group membership) is primary, Option B (`user_id` allowlist)
+  is an OR-override/fallback. Fail-closed if neither is configured in remote mode. — *Decided.*
+- **Part 4 (local setups)**: loopback-bound deployments skip Zotero-key auth and the gate
+  completely; every other deployment requires zotero.org auth, with no shared-key opt-out.
+  Options 4.2 and 4.3 are rejected as permanent modes. — *Decided.*
+
+## Open decisions still to confirm before implementation
+
+1. **Group-library destructive ops**: any group member can currently pass the read gate. Should
+   `DELETE`/sync-deletions on a *group* library be allowed for any member, or restricted (e.g. to
+   the first indexer, or require write scope on that group)? Read (query) for any member is fine.
+2. **Migration window length** for the short transitional dual-auth phase in Part 5.
+3. Whether `https://www.zotero.org/settings/keys/new` accepts prefill query params to streamline
+   the wizard (needs a quick check).
+
+---
+
+## Part 6 — Documentation and tests to update
+
+### Documentation
+
+| Doc | Update needed |
+| --- | --- |
+| `CLAUDE.md` (root) | The "Debugging the cron indexer" section documents `AUTOINDEX_SECRET` and the read-only-key submission flow (`bin/autoindex_add_key.py`) as a separate, optional feature from normal plugin use. Once the Zotero key becomes mandatory for all plugin use, fold this into a single "Zotero identity" story: the same key now gates login *and* (optionally) auto-indexing, so the doc should stop describing key submission as an auto-index-only side path. |
+| `docs/cron-indexing.md` | Update the key-source description: keys now arrive via the mandatory login/setup-wizard flow, not only via manual opt-in for auto-indexing. Re-check any statement implying auto-index keys are the *only* key type stored/used by the server. |
+| `docs/architecture.md` | Add/update the auth section: replace the "shared `X-API-Key` middleware" description with the per-request Zotero-identity dependency, the validation cache, and the Part 2 access gate. Document the loopback no-auth exception explicitly as an intentional, guarded special case (not a leftover). |
+| `.env.dist` / deploy env template docs | Remove or relabel `API_KEY` as loopback/local-only; add `AUTHORIZED_GROUP_ID` and `AUTHORIZED_USER_IDS` (new, required in remote mode) with examples; note the fail-closed startup check. |
+| Plugin-facing docs (`plugin/README.md` if present, or preferences help text) | Document the new mandatory setup wizard, the "Create key on zotero.org" step, required key scopes (personal library read + all-groups read), and what "access denied — request group membership" means for the end user. |
+| New doc, e.g. `docs/zotero-auth.md` | Consider a dedicated reference doc for the new identity/gate model (validation cache TTL, `targets` semantics, group-gate vs allowlist precedence) so it isn't scattered across cron-indexing and architecture docs. |
+| `docs/history/master.md` (per `CLAUDE.md`'s implementation-progress convention) | If this plan is executed as a phased implementation, add per-phase progress docs under `docs/history/` and link a short summary from `master.md`, per the project's documented convention for master implementation plans. |
+
+### Tests
+
+| Area | Update needed |
+| --- | --- |
+| Auth middleware / dependency | New unit tests for `require_zotero_identity`: valid key → identity attached; invalid/revoked key → 401; zotero.org unreachable with no cache → 503; zotero.org unreachable with a warm cache → served from cache. |
+| Access gate (Part 2) | Unit tests: key in authorized group → pass; key not in group and not in allowlist → 403; key not in group but `user_id` in allowlist → pass (OR-override); neither `AUTHORIZED_GROUP_ID` nor `AUTHORIZED_USER_IDS` set in remote mode → server refuses to start (fail-closed), covered as a startup/config test. |
+| `backend/api/query.py` | Test that `POST /api/query` 403s when a `library_ids` entry is outside the caller's `targets`, and succeeds when inside. Replace/extend any existing test that relied on the old shared-key-only auth. |
+| `backend/api/libraries.py` | Test that `GET /api/libraries` returns only the caller's own libraries (filtered by `targets`), not the full registry. Test that `DELETE .../index`, sync-deletions, item-chunk delete, and batch-metadata all 403 for out-of-target library IDs. |
+| `backend/api/document_upload.py` | Remove/replace tests that pass `user_id` in the request body as the trust boundary; add a test confirming `user_id` is now taken from the validated identity and that a body-supplied `user_id` is ignored. Test `_check_registration`'s (or its replacement's) localhost bypass still works together with the new loopback no-auth path — clarify whether `_check_registration` is superseded or kept as bookkeeping only. |
+| Loopback no-auth mode (Part 4) | Test that a request to a non-loopback `api_host` with auth disabled is rejected at startup/config validation (the guardrail), and that loopback mode genuinely skips both the Zotero-key check and the Part 2 gate. |
+| Validation cache (1.3) | Unit test for TTL expiry/refresh behavior and for serving a stale cache entry on a transient zotero.org failure vs. a hard failure (revoked key) which must not be masked by a stale "valid" cache entry. |
+| Plugin (`plugin/test/` or equivalent) | Tests for `getAuthHeaders()` sending `X-Zotero-API-Key` instead of/in addition to `X-API-Key` during the transitional window; setup-wizard flow (mock `POST /api/auth/validate` success/gate-failure responses). |
+| Migration/dual-auth window (Part 5 step 2) | Test that the transitional server accepts *either* a valid Zotero key *or* the legacy `API_KEY`, and that legacy-path usage is logged (so the operator can verify before cutover). Remove this test once the legacy path is removed in step 4. |
+| Container/startup smoke test | If `docker-compose`/`container.mjs` startup behavior changes (e.g. fail-closed check reading `AUTHORIZED_GROUP_ID`), re-run `uv run pytest -m container -v -s` and update `scripts/test_startup_sequence.py` expectations per `CLAUDE.md`'s existing container-smoke-test guidance. |

--- a/docs/superpowers/plans/2026-07-06-zotero-key-auth-backend.md
+++ b/docs/superpowers/plans/2026-07-06-zotero-key-auth-backend.md
@@ -1,0 +1,1768 @@
+# Zotero-Key Backend Auth (IDOR Fix) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the cross-tenant IDOR in the backend (any shared-key holder can read/delete any other user's library) by authenticating every non-loopback `/api/*` request with the caller's own validated, gate-approved Zotero API key, and enforcing that every `library_id` named in a request is within that key's readable targets.
+
+**Architecture:** A single async resolver (`resolve_zotero_identity`) turns a request's headers into an `Optional[ZoteroIdentity]`: `None` on the loopback path (single trusted local user, Part 4 of the design doc) and on the transitional legacy-shared-key path (Part 5); otherwise a validated `(user_id, username, targets)` gated by group-membership-or-allowlist (Part 2). The existing `api_key_middleware` in `backend/main.py` calls this resolver once per request for every `/api/*` path and stashes the result on `request.state.zotero_identity`; a cheap dependency (`get_zotero_identity`) lets route handlers read it back without re-validating. Handlers that name a `library_id` call `assert_can_access(identity, library_id)`, which is a no-op for `None` and a 403 otherwise. A startup check (`assert_safe_to_start`) refuses to boot in remote mode without a configured access gate (fail-closed).
+
+**Tech Stack:** FastAPI (dependency injection + ASGI middleware), `aiohttp` (Zotero API calls via the existing `key_validator.validate_key`), Python stdlib `unittest` + `aioresponses`/`unittest.mock.AsyncMock` (existing test conventions in `backend/tests/`).
+
+**Source spec:** `docs/history/plan-zotero-key-auth.md` (Parts 1, 2, 4; Part 5 step 2 only — the transitional dual-auth window). Parts 3 (plugin wizard) and the rest of Part 5 (cutover) are a separate follow-up plan once these backend endpoints exist.
+
+**Explicitly out of scope for this plan** (not named in the vulnerability report or the design doc's Part 1.2 table — left for a follow-up if desired): `GET /api/libraries/{id}/status`, `GET /api/libraries/{id}/index-status`, `POST /api/libraries/{id}/reconcile-count`. These remain reachable by any gate-authorized identity without per-library filtering, same as today's behavior for any shared-key holder — no regression, just not hardened in this pass.
+
+---
+
+### Task 1: Settings — access-gate configuration fields
+
+**Files:**
+- Modify: `backend/config/settings.py:163-173` (insert new fields after `zotero_api_key`, before `require_registration`)
+- Test: `backend/tests/test_settings_access_gate.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Unit tests for the Part 2 access-gate settings fields."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from backend.config.settings import Settings
+
+
+class AccessGateSettingsTest(unittest.TestCase):
+    def test_authorized_group_id_defaults_none(self):
+        s = Settings()
+        self.assertIsNone(s.authorized_group_id)
+
+    def test_authorized_user_ids_defaults_empty(self):
+        s = Settings()
+        self.assertEqual(s.authorized_user_ids, [])
+
+    def test_authorized_group_id_from_env(self):
+        with patch.dict(os.environ, {"AUTHORIZED_GROUP_ID": "998877"}):
+            s = Settings()
+        self.assertEqual(s.authorized_group_id, 998877)
+
+    def test_authorized_user_ids_parses_comma_separated_env(self):
+        with patch.dict(os.environ, {"AUTHORIZED_USER_IDS": "123, 456"}):
+            s = Settings()
+        self.assertEqual(s.authorized_user_ids, [123, 456])
+
+    def test_authorized_user_ids_accepts_list(self):
+        s = Settings(authorized_user_ids=[1, 2])
+        self.assertEqual(s.authorized_user_ids, [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_settings_access_gate.py -v`
+Expected: FAIL — `Settings` has no field `authorized_group_id` (pydantic ignores unknown kwargs silently by default in this project's `extra="ignore"` config, so the first two tests fail on `AttributeError: 'Settings' object has no attribute 'authorized_group_id'`).
+
+- [ ] **Step 3: Add the fields**
+
+In `backend/config/settings.py`, insert immediately after the `zotero_api_key` field (currently lines 163-167) and before `require_registration`:
+
+```python
+    authorized_group_id: Optional[int] = Field(
+        default=None,
+        description="Zotero group ID that gates access to this instance in remote mode. "
+                    "A caller's validated Zotero key must grant read access to "
+                    "groups/<id> (i.e. the caller is a member of this group) to be "
+                    "authorized. Combines with AUTHORIZED_USER_IDS via OR. "
+                    "Ignored on loopback deployments (api_host=localhost/127.0.0.1)."
+    )
+    authorized_user_ids: list[int] = Field(
+        default=[],
+        description="Explicit allowlist of Zotero user IDs authorized to use this "
+                    "instance in remote mode, in addition to AUTHORIZED_GROUP_ID "
+                    "membership (OR semantics). Comma-separated list of integers "
+                    "in the environment. At least one of AUTHORIZED_GROUP_ID / "
+                    "AUTHORIZED_USER_IDS must be set for the server to start in "
+                    "remote mode — see backend.services.access_gate.assert_safe_to_start."
+    )
+
+    @field_validator("authorized_user_ids", mode="before")
+    @classmethod
+    def parse_authorized_user_ids(cls, v):
+        if isinstance(v, list):
+            return [int(x) for x in v]
+        if isinstance(v, str):
+            return [int(x.strip()) for x in v.split(",") if x.strip()]
+        return v
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_settings_access_gate.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/config/settings.py backend/tests/test_settings_access_gate.py
+git commit -m "feat: add AUTHORIZED_GROUP_ID / AUTHORIZED_USER_IDS settings"
+```
+
+---
+
+### Task 2: Zotero identity validation cache
+
+**Files:**
+- Create: `backend/services/zotero_identity.py`
+- Test: `backend/tests/test_zotero_identity.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Unit tests for backend.services.zotero_identity (the Part 1.3 validation cache)."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from backend.services.zotero_identity import ZoteroIdentity, ZoteroIdentityCache
+from backend.zotero.key_validator import KeyValidation
+
+
+class ZoteroIdentityCacheTest(unittest.IsolatedAsyncioTestCase):
+    async def test_caches_successful_validation(self):
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        mock_validate = AsyncMock(return_value=validation)
+        cache = ZoteroIdentityCache(ttl_seconds=60)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, validation)
+        self.assertIs(second, validation)
+        mock_validate.assert_awaited_once()
+
+    async def test_expired_entry_revalidates(self):
+        old = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        new = KeyValidation(user_id=1, username="u", targets=["users/1", "groups/2"], read_only=True)
+        mock_validate = AsyncMock(side_effect=[old, new])
+        cache = ZoteroIdentityCache(ttl_seconds=0)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, old)
+        self.assertIs(second, new)
+        self.assertEqual(mock_validate.await_count, 2)
+
+    async def test_transient_failure_serves_stale_cache(self):
+        good = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        transient_failure = KeyValidation(None, None, read_only=False, reason="down", transient=True)
+        mock_validate = AsyncMock(side_effect=[good, transient_failure])
+        cache = ZoteroIdentityCache(ttl_seconds=0)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, good)
+        self.assertIs(second, good)  # stale cache served instead of the transient failure
+
+    async def test_hard_failure_not_masked_by_stale_cache(self):
+        good = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        revoked = KeyValidation(None, None, read_only=False, reason="revoked", transient=False)
+        mock_validate = AsyncMock(side_effect=[good, revoked])
+        cache = ZoteroIdentityCache(ttl_seconds=0)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            first = await cache.resolve("KEY")
+            second = await cache.resolve("KEY")
+        self.assertIs(first, good)
+        self.assertIs(second, revoked)  # a hard failure always overwrites the cache
+
+    async def test_no_cache_entry_and_transient_failure_propagates(self):
+        transient_failure = KeyValidation(None, None, read_only=False, reason="down", transient=True)
+        mock_validate = AsyncMock(return_value=transient_failure)
+        cache = ZoteroIdentityCache(ttl_seconds=60)
+        with patch("backend.services.zotero_identity.validate_key", new=mock_validate):
+            result = await cache.resolve("KEY")
+        self.assertIs(result, transient_failure)
+
+    def test_zotero_identity_is_a_plain_value_object(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self.assertEqual(identity.user_id, 1)
+        self.assertEqual(identity.username, "u")
+        self.assertEqual(identity.targets, ["users/1"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_zotero_identity.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'backend.services.zotero_identity'`
+
+- [ ] **Step 3: Implement the module**
+
+```python
+"""Zotero-key identity resolution and caching (Part 1.3 of the design).
+
+A Zotero API key resolves to a stable identity — (user_id, username, targets)
+— via backend.zotero.key_validator.validate_key(), which calls
+api.zotero.org. That call is too slow and too fragile to make on every
+request, so ZoteroIdentityCache caches the result per key fingerprint with a
+TTL. A transient zotero.org failure (5xx, network error) serves a still-cached
+entry rather than failing the request; a hard failure (revoked key, write
+scope, no readable library) always overwrites the cache so it is never masked
+by stale "valid" data.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+
+from backend.zotero.key_validator import KeyValidation, validate_key
+from backend.services.autoindex_key_store import fingerprint
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 600
+
+
+@dataclass
+class ZoteroIdentity:
+    """A validated, gate-approved Zotero identity resolved from an API key."""
+
+    user_id: int
+    username: str
+    targets: list[str]
+
+
+class ZoteroIdentityCache:
+    """In-memory TTL cache of KeyValidation results, keyed by key fingerprint."""
+
+    def __init__(self, ttl_seconds: int = CACHE_TTL_SECONDS) -> None:
+        self._ttl = ttl_seconds
+        self._entries: dict[str, tuple[float, KeyValidation]] = {}
+
+    async def resolve(self, api_key: str) -> KeyValidation:
+        """Return a cached or freshly validated KeyValidation for api_key."""
+        fp = fingerprint(api_key)
+        now = time.monotonic()
+        cached = self._entries.get(fp)
+        if cached is not None and now - cached[0] < self._ttl:
+            return cached[1]
+
+        result = await validate_key(api_key)
+        if result.transient and cached is not None:
+            logger.warning("zotero.org validation failed transiently; serving stale cache for %s", fp)
+            return cached[1]
+        if not result.transient:
+            self._entries[fp] = (now, result)
+        return result
+
+    def clear(self) -> None:
+        """Test helper: drop all cached entries."""
+        self._entries.clear()
+
+
+_cache = ZoteroIdentityCache()
+
+
+def get_identity_cache() -> ZoteroIdentityCache:
+    """Return the process-wide identity cache used by the auth middleware."""
+    return _cache
+
+
+def reset_identity_cache() -> None:
+    """Test helper: clear the process-wide cache between test cases."""
+    _cache.clear()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_zotero_identity.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/zotero_identity.py backend/tests/test_zotero_identity.py
+git commit -m "feat: add Zotero-key identity validation cache"
+```
+
+---
+
+### Task 3: Access gate (Part 2) + startup fail-closed check + per-library enforcement helper
+
+**Files:**
+- Create: `backend/services/access_gate.py`
+- Test: `backend/tests/test_access_gate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Unit tests for backend.services.access_gate (Part 2 gate, Part 4 loopback
+exception, and the per-library enforcement helper used by route handlers)."""
+
+import unittest
+
+from fastapi import HTTPException
+
+from backend.config.settings import Settings
+from backend.services.access_gate import (
+    assert_can_access,
+    assert_safe_to_start,
+    is_gate_configured,
+    is_loopback,
+    passes_gate,
+)
+from backend.services.zotero_identity import ZoteroIdentity
+
+
+class LoopbackTest(unittest.TestCase):
+    def test_localhost_is_loopback(self):
+        self.assertTrue(is_loopback(Settings(api_host="localhost")))
+
+    def test_127_0_0_1_is_loopback(self):
+        self.assertTrue(is_loopback(Settings(api_host="127.0.0.1")))
+
+    def test_fqdn_is_not_loopback(self):
+        self.assertFalse(is_loopback(Settings(api_host="rag.example.com")))
+
+
+class GateConfiguredTest(unittest.TestCase):
+    def test_unconfigured(self):
+        self.assertFalse(is_gate_configured(Settings()))
+
+    def test_group_configured(self):
+        self.assertTrue(is_gate_configured(Settings(authorized_group_id=1)))
+
+    def test_allowlist_configured(self):
+        self.assertTrue(is_gate_configured(Settings(authorized_user_ids=[1])))
+
+
+class PassesGateTest(unittest.TestCase):
+    def test_group_member_passes(self):
+        settings = Settings(authorized_group_id=999)
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1", "groups/999"])
+        self.assertTrue(passes_gate(identity, settings))
+
+    def test_non_member_without_allowlist_fails(self):
+        settings = Settings(authorized_group_id=999)
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self.assertFalse(passes_gate(identity, settings))
+
+    def test_allowlisted_user_passes_even_without_group_membership(self):
+        settings = Settings(authorized_group_id=999, authorized_user_ids=[1])
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self.assertTrue(passes_gate(identity, settings))
+
+    def test_neither_configured_fails_closed(self):
+        settings = Settings()
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1", "groups/999"])
+        self.assertFalse(passes_gate(identity, settings))
+
+
+class AssertSafeToStartTest(unittest.TestCase):
+    def test_loopback_always_safe(self):
+        assert_safe_to_start(Settings(api_host="localhost"))  # must not raise
+
+    def test_remote_without_gate_raises(self):
+        with self.assertRaises(RuntimeError):
+            assert_safe_to_start(Settings(api_host="rag.example.com"))
+
+    def test_remote_with_group_configured_is_safe(self):
+        assert_safe_to_start(Settings(api_host="rag.example.com", authorized_group_id=999))
+
+    def test_remote_with_allowlist_configured_is_safe(self):
+        assert_safe_to_start(Settings(api_host="rag.example.com", authorized_user_ids=[1]))
+
+
+class AssertCanAccessTest(unittest.TestCase):
+    def test_none_identity_always_allowed(self):
+        assert_can_access(None, "users/1")  # must not raise
+
+    def test_identity_with_target_allowed(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        assert_can_access(identity, "users/1")  # must not raise
+
+    def test_identity_without_target_rejected(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        with self.assertRaises(HTTPException) as ctx:
+            assert_can_access(identity, "users/2")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_access_gate.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'backend.services.access_gate'`
+
+- [ ] **Step 3: Implement the module**
+
+```python
+"""The Part 2 access gate and Part 4 loopback exception.
+
+zotero_identity.py proves "this is a real Zotero user with these readable
+libraries." That is authentication, not authorization to use this instance —
+any Zotero account on earth can pass it. This module adds the second check:
+is the identity a member of a designated Zotero group, or on an explicit
+user_id allowlist? It also holds the per-library enforcement helper used by
+route handlers, and the startup check that refuses to run an unguarded
+remote instance.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import HTTPException
+
+from backend.config.settings import Settings
+from backend.services.zotero_identity import ZoteroIdentity
+
+logger = logging.getLogger(__name__)
+
+
+def is_loopback(settings: Settings) -> bool:
+    """True for the single-trusted-local-user deployment mode (Part 4)."""
+    return settings.api_host in ("localhost", "127.0.0.1")
+
+
+def is_gate_configured(settings: Settings) -> bool:
+    return bool(settings.authorized_group_id) or bool(settings.authorized_user_ids)
+
+
+def passes_gate(identity: ZoteroIdentity, settings: Settings) -> bool:
+    """True if identity is allowed to use this instance at all (Part 2)."""
+    if settings.authorized_group_id and f"groups/{settings.authorized_group_id}" in identity.targets:
+        return True
+    if settings.authorized_user_ids and identity.user_id in settings.authorized_user_ids:
+        return True
+    return False
+
+
+def assert_safe_to_start(settings: Settings) -> None:
+    """Refuse to start in remote mode without a configured access gate.
+
+    Loopback deployments are exempt: a single trusted local user needs no
+    gate. Remote deployments must configure AUTHORIZED_GROUP_ID and/or
+    AUTHORIZED_USER_IDS, or every Zotero user on earth could use the instance.
+    """
+    if is_loopback(settings):
+        return
+    if not is_gate_configured(settings):
+        raise RuntimeError(
+            f"Refusing to start in remote mode (api_host={settings.api_host!r}) "
+            "without an access gate: set AUTHORIZED_GROUP_ID and/or "
+            "AUTHORIZED_USER_IDS. See docs/history/plan-zotero-key-auth.md Part 2."
+        )
+
+
+def assert_can_access(identity: Optional[ZoteroIdentity], library_id: str) -> None:
+    """Raise 403 unless library_id is within identity's readable targets.
+
+    identity=None means the caller is on the loopback no-auth path (Part 4)
+    or the transitional legacy-shared-key path (Part 5) — both bypass
+    per-library enforcement (loopback because there is only one trusted
+    user; legacy because un-migrated plugins predate per-library targets).
+    """
+    if identity is None:
+        return
+    if library_id not in identity.targets:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Your Zotero key does not grant read access to library {library_id!r}.",
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_access_gate.py -v`
+Expected: PASS (14 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/access_gate.py backend/tests/test_access_gate.py
+git commit -m "feat: add Part 2 access gate and per-library enforcement helper"
+```
+
+---
+
+### Task 4: `resolve_zotero_identity` — the request-level resolver
+
+**Files:**
+- Modify: `backend/dependencies.py` (add near the top, after the imports and before `get_client_api_keys`)
+- Test: `backend/tests/test_resolve_zotero_identity.py`
+
+This is the function that turns request headers into an `Optional[ZoteroIdentity]`, combining the loopback exception, the legacy-shared-key transitional fallback, the identity cache, and the Part 2 gate. It is tested standalone here (via a throwaway FastAPI app, not the real one) so its own branches are covered in isolation before Task 5 wires it into `backend/main.py`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Unit tests for backend.dependencies.resolve_zotero_identity, tested in
+isolation via a throwaway FastAPI app (not backend.main.app)."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from backend.config.settings import get_settings, reset_settings
+from backend.dependencies import resolve_zotero_identity
+from backend.services.zotero_identity import reset_identity_cache
+from backend.zotero.key_validator import KeyValidation
+
+
+def _make_probe_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(identity=Depends(resolve_zotero_identity)):
+        if identity is None:
+            return {"identity": None}
+        return {"user_id": identity.user_id, "targets": identity.targets}
+
+    return app
+
+
+class ResolveZoteroIdentityTest(unittest.TestCase):
+    def setUp(self):
+        reset_settings()
+        reset_identity_cache()
+        self.client = TestClient(_make_probe_app())
+
+    def tearDown(self):
+        reset_settings()
+        reset_identity_cache()
+
+    def test_loopback_skips_auth_entirely(self):
+        get_settings().api_host = "localhost"
+        r = self.client.get("/probe")
+        self.assertEqual(r.status_code, 200)
+        self.assertIsNone(r.json()["identity"])
+
+    def test_remote_missing_key_rejected(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/probe")
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_valid_gated_key_returns_identity(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1", "groups/999"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["user_id"], 1)
+
+    def test_remote_valid_but_ungated_key_rejected(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 403)
+
+    def test_remote_revoked_key_rejected_with_401(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(None, None, read_only=False, reason="revoked", transient=False)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_zotero_unreachable_no_cache_returns_503(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(None, None, read_only=False, reason="down", transient=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/probe", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 503)
+
+    def test_legacy_shared_key_accepted_as_transitional_fallback(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/probe", headers={"X-API-Key": "SHARED"})
+        self.assertEqual(r.status_code, 200)
+        self.assertIsNone(r.json()["identity"])
+
+    def test_legacy_key_via_query_param_accepted(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/probe?api_key=SHARED")
+        self.assertEqual(r.status_code, 200)
+
+    def test_wrong_legacy_key_rejected(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/probe", headers={"X-API-Key": "WRONG"})
+        self.assertEqual(r.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_resolve_zotero_identity.py -v`
+Expected: FAIL — `ImportError: cannot import name 'resolve_zotero_identity' from 'backend.dependencies'`
+
+- [ ] **Step 3: Implement the resolver and the state-reading dependency**
+
+In `backend/dependencies.py`, add these imports alongside the existing ones at the top of the file:
+
+```python
+from typing import Optional
+
+from fastapi import HTTPException, Request
+
+from backend.services.access_gate import is_loopback, passes_gate
+from backend.services.zotero_identity import ZoteroIdentity, get_identity_cache
+```
+
+(`Request` is already imported; keep the existing `from fastapi import Request` line and just add `HTTPException` to it instead of duplicating the import.)
+
+Then add the resolver and reader, placed after the imports and before `get_client_api_keys`:
+
+```python
+async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
+    """Resolve and gate the caller's Zotero identity for the current request.
+
+    Returns None for the loopback no-auth path (Part 4) and for the
+    transitional legacy-shared-key path (Part 5) — both skip per-library
+    enforcement in access_gate.assert_can_access(). Raises HTTPException:
+    401 for a missing/invalid/revoked key, 403 if the Part 2 gate rejects
+    an otherwise-valid identity, 503 if zotero.org is unreachable with no
+    cached validation to fall back on.
+
+    Used both as a FastAPI dependency (directly, or via get_zotero_identity
+    reading back what the api_key_middleware already resolved) and as the
+    middleware's own auth check for every /api/* request.
+    """
+    settings = get_settings()
+    if is_loopback(settings):
+        return None
+
+    zotero_key = request.headers.get("X-Zotero-API-Key")
+    if not zotero_key:
+        legacy_key = request.headers.get("X-API-Key") or request.query_params.get("api_key")
+        if settings.api_key and legacy_key == settings.api_key:
+            logger.warning("Request authenticated via legacy shared API_KEY (transitional path)")
+            return None
+        raise HTTPException(status_code=401, detail="Missing X-Zotero-API-Key header.")
+
+    validation = await get_identity_cache().resolve(zotero_key)
+    if not validation.read_only:
+        status_code = 503 if validation.transient else 401
+        raise HTTPException(status_code=status_code, detail=validation.reason or "Invalid Zotero API key.")
+
+    identity = ZoteroIdentity(user_id=validation.user_id, username=validation.username, targets=validation.targets)
+    if not passes_gate(identity, settings):
+        raise HTTPException(status_code=403, detail="This Zotero account is not authorized to use this server.")
+    return identity
+
+
+def get_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
+    """FastAPI dependency: read back the identity api_key_middleware resolved.
+
+    Route handlers should depend on this (not resolve_zotero_identity
+    directly) to avoid re-validating the key a second time per request.
+    Returns None if the middleware never ran for this path (shouldn't
+    happen for any /api/* route) or resolved to the loopback/legacy path.
+    """
+    return getattr(request.state, "zotero_identity", None)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_resolve_zotero_identity.py -v`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Run the full existing suite to check for regressions before wiring anything else**
+
+Run: `uv run pytest backend/tests -x -q`
+Expected: PASS, same pass count as before this task (no existing test touches `backend/dependencies.py`'s new additions yet)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/dependencies.py backend/tests/test_resolve_zotero_identity.py
+git commit -m "feat: add resolve_zotero_identity request resolver"
+```
+
+---
+
+### Task 5: Wire the resolver into `backend/main.py` (middleware + fail-closed startup)
+
+**Files:**
+- Modify: `backend/main.py:1-21` (imports, startup), `backend/main.py:140-168` (middleware)
+- Test: `backend/tests/test_main_auth_middleware.py`
+
+This task makes the new resolver run for **every** `/api/*` path (not just the ones touched later in this plan), replacing the old single-shared-secret check app-wide. Since every existing test uses the default `api_host="localhost"` (loopback), this is a no-op for the whole existing suite — verified in Step 5.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""End-to-end tests for the api_key_middleware wiring in backend.main.
+
+Uses the real app (TestClient(app)) and an already-existing, unmodified
+route (GET /api/libraries) purely to exercise the middleware's status-code
+behavior. Response *content* filtering is covered later once
+backend/api/libraries.py itself is wired (see test_libraries_api.py)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.zotero_identity import reset_identity_cache
+from backend.zotero.key_validator import KeyValidation
+
+
+class AuthMiddlewareTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def test_loopback_reaches_handler_without_any_key(self):
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 200)
+
+    def test_remote_without_any_key_is_401(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_with_gated_zotero_key_reaches_handler(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="u", targets=["users/1", "groups/999"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/api/libraries", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_remote_with_legacy_shared_key_still_works(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        s.api_key = "SHARED"
+        r = self.client.get("/api/libraries", headers={"X-API-Key": "SHARED"})
+        self.assertEqual(r.status_code, 200)
+
+    def test_health_and_version_exempt_even_on_remote_host(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        self.assertEqual(self.client.get("/health").status_code, 200)
+        self.assertEqual(self.client.get("/api/version").status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_main_auth_middleware.py -v`
+Expected: FAIL on the remote-host tests — the old middleware 401s on a missing/mismatched `X-API-Key` even when no `api_key` is configured to compare against is a non-issue today (it's a no-op when `settings.api_key` is unset), but the *new* behaviors (rejecting on a bare remote host with no key at all when `api_key` is unset, accepting a valid gated Zotero key) don't exist yet.
+
+- [ ] **Step 3: Replace the middleware and add the startup check**
+
+In `backend/main.py`, change the import line (currently `from fastapi import FastAPI, Request`):
+
+```python
+from fastapi import FastAPI, HTTPException, Request
+```
+
+Add two imports near the other `backend.*` imports (after `from backend.dependencies import make_vector_store`):
+
+```python
+from backend.dependencies import resolve_zotero_identity
+from backend.services.access_gate import assert_safe_to_start
+```
+
+Immediately after `settings = get_settings()` (currently line 21), add:
+
+```python
+assert_safe_to_start(settings)
+```
+
+Replace the entire middleware block (currently lines ~140-168, from the `# API key authentication middleware` comment through the end of `api_key_middleware`) with:
+
+```python
+# Zotero-key identity middleware
+# Resolves and gates the caller's identity for every /api/* request — see
+# docs/history/plan-zotero-key-auth.md for the design. Exempt health-check /
+# version endpoints so the plugin can discover the backend without needing
+# credentials first, and /public/* which is intentionally unauthenticated.
+_AUTH_EXEMPT_PATHS = {"/", "/health", "/api/version"}
+
+
+@app.middleware("http")
+async def api_key_middleware(request: Request, call_next):
+    """Resolve and gate the caller's Zotero identity for every /api/* request.
+
+    Loopback deployments (api_host in {localhost, 127.0.0.1}) skip this
+    entirely (Part 4) — there is exactly one trusted local user. Everywhere
+    else the caller must present either a valid, gate-approved Zotero API
+    key (X-Zotero-API-Key) or, during the transitional migration window, the
+    legacy shared secret (X-API-Key header / ?api_key= query param — the
+    latter for SSE endpoints where EventSource cannot set headers). The
+    resolved identity (or None for loopback/legacy) is stashed on
+    request.state.zotero_identity so downstream route dependencies
+    (backend.dependencies.get_zotero_identity) don't re-validate.
+
+    OPTIONS requests (CORS preflight) are always allowed so the browser can
+    complete the preflight handshake.
+    """
+    request.state.zotero_identity = None
+    if (
+        request.method != "OPTIONS"
+        and request.url.path.startswith("/api/")
+        and request.url.path not in _AUTH_EXEMPT_PATHS
+    ):
+        try:
+            request.state.zotero_identity = await resolve_zotero_identity(request)
+        except HTTPException as exc:
+            return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+    return await call_next(request)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_main_auth_middleware.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Run the full existing suite to confirm no regressions**
+
+Run: `uv run pytest backend/tests -x -q`
+Expected: PASS. Every pre-existing test uses the default `api_host="localhost"`, so the new middleware takes the loopback branch exactly as the old middleware did when `api_key` was unset — no behavioral change for the existing suite. (`test_autoindex_api.py`'s `s.api_key = None` line becomes redundant but harmless — the loopback branch is checked first regardless.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/main.py backend/tests/test_main_auth_middleware.py
+git commit -m "feat: replace shared-secret middleware with Zotero-key identity resolution"
+```
+
+---
+
+### Task 6: Enforce access on `POST /api/query`
+
+**Files:**
+- Modify: `backend/api/query.py:1-63` (imports, handler signature), `backend/api/query.py:79-83` (enforcement)
+- Test: `backend/tests/test_query_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Endpoint tests for POST /api/query's per-library authorization."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+import backend.dependencies as dependencies
+
+
+class QueryAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        s.testing = True
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def _set_identity(self, identity):
+        """Bypass the middleware/network round-trip: override the
+        get_zotero_identity dependency directly, matching how FastAPI's own
+        dependency_overrides mechanism is meant to be used in tests."""
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def tearDown_overrides(self):
+        app.dependency_overrides.clear()
+
+    def test_loopback_query_with_no_identity_is_unrestricted(self):
+        self._set_identity(None)
+        try:
+            r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/1"]})
+        finally:
+            app.dependency_overrides.clear()
+        self.assertNotEqual(r.status_code, 403)
+
+    def test_query_outside_targets_is_403(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self._set_identity(identity)
+        try:
+            r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/2"]})
+        finally:
+            app.dependency_overrides.clear()
+        self.assertEqual(r.status_code, 403)
+
+    def test_query_within_targets_is_not_403(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self._set_identity(identity)
+        try:
+            r = self.client.post("/api/query", json={"question": "q?", "library_ids": ["users/1"]})
+        finally:
+            app.dependency_overrides.clear()
+        self.assertNotEqual(r.status_code, 403)
+
+    def test_query_with_one_target_outside_is_403_even_if_another_is_inside(self):
+        identity = ZoteroIdentity(user_id=1, username="u", targets=["users/1"])
+        self._set_identity(identity)
+        try:
+            r = self.client.post(
+                "/api/query",
+                json={"question": "q?", "library_ids": ["users/1", "users/2"]},
+            )
+        finally:
+            app.dependency_overrides.clear()
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_query_api.py -v`
+Expected: FAIL on the two 403 tests (the 403 is never raised today) — `AssertionError: 200 != 403` or similar, depending on what `MockLLMService`/`MockEmbeddingService` do with a nonexistent library (should not itself error, since `s.testing = True` uses mocks).
+
+- [ ] **Step 3: Wire the dependency and enforcement**
+
+In `backend/api/query.py`, change the import line:
+
+```python
+from backend.dependencies import get_client_api_keys, get_vector_store, get_zotero_identity, make_embedding_service, make_llm_service
+```
+
+Add two new imports:
+
+```python
+from backend.services.access_gate import assert_can_access
+from backend.services.zotero_identity import ZoteroIdentity
+```
+
+Change the handler signature (currently lines 58-63):
+
+```python
+@router.post("/query", response_model=QueryResponse)
+async def query_libraries(
+    query: QueryRequest,
+    http_request: Request,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+```
+
+Add the enforcement loop right after the existing "at least one library ID" check (currently lines 79-83):
+
+```python
+    if not query.library_ids:
+        raise HTTPException(
+            status_code=400,
+            detail="At least one library ID must be provided"
+        )
+
+    for library_id in query.library_ids:
+        assert_can_access(identity, library_id)
+
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_query_api.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run the full existing suite to confirm no regressions**
+
+Run: `uv run pytest backend/tests -x -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/api/query.py backend/tests/test_query_api.py
+git commit -m "fix: enforce per-library access on POST /api/query"
+```
+
+---
+
+### Task 7: Enforce access on `backend/api/libraries.py` (list filtering + delete/mutate endpoints)
+
+**Files:**
+- Modify: `backend/api/libraries.py` (imports; `list_libraries` at ~line 80; `clear_library_index` at ~line 152; `sync_library_deletions` at ~line 234; `clear_item_chunks` at ~line 273)
+- Test: `backend/tests/test_libraries_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Endpoint tests for backend.api.libraries authorization:
+- GET /api/libraries is filtered to the caller's own targets
+- DELETE .../index, POST .../sync-deletions, DELETE .../items/{key}/chunks
+  all 403 for a library outside the caller's targets
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.db.vector_store import VectorStore
+from backend.models.library import LibraryIndexMetadata
+from backend.services.registration_service import RegistrationService
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+import backend.dependencies as dependencies
+
+
+class LibrariesAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        s.testing = True
+        self.client = TestClient(app)
+
+        vector_store = VectorStore(
+            storage_path=Path(self.tmp.name) / "qdrant",
+            embedding_dim=8,
+            embedding_model_name="test-model",
+        )
+        vector_store.update_library_metadata(
+            LibraryIndexMetadata(library_id="users/1", library_type="user", library_name="Mine")
+        )
+        vector_store.update_library_metadata(
+            LibraryIndexMetadata(library_id="users/2", library_type="user", library_name="Someone Else's")
+        )
+        app.state.vector_store = vector_store
+
+        RegistrationService(s.registrations_path).register("users/1", "Mine", 1, "u")
+        RegistrationService(s.registrations_path).register("users/2", "Someone Else's", 2, "other")
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def _set_identity(self, identity):
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def test_list_filters_to_own_targets(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 200)
+        ids = [lib["library_id"] for lib in r.json()]
+        self.assertEqual(ids, ["users/1"])
+
+    def test_list_unrestricted_when_no_identity(self):
+        self._set_identity(None)
+        r = self.client.get("/api/libraries")
+        self.assertEqual(r.status_code, 200)
+        ids = {lib["library_id"] for lib in r.json()}
+        self.assertEqual(ids, {"users/1", "users/2"})
+
+    def test_delete_index_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.delete("/api/libraries/users/2/index")
+        self.assertEqual(r.status_code, 403)
+
+    def test_delete_index_within_targets_succeeds(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.delete("/api/libraries/users/1/index")
+        self.assertEqual(r.status_code, 200)
+
+    def test_sync_deletions_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post("/api/libraries/users/2/sync-deletions", json={"current_item_keys": []})
+        self.assertEqual(r.status_code, 403)
+
+    def test_clear_item_chunks_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.delete("/api/libraries/users/2/items/ITEM1/chunks")
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_libraries_api.py -v`
+Expected: FAIL — `test_list_filters_to_own_targets` sees both libraries; the three 403 tests get 200 instead.
+
+- [ ] **Step 3: Wire the dependency and enforcement**
+
+In `backend/api/libraries.py`, add to the imports:
+
+```python
+from typing import Optional
+
+from backend.dependencies import get_vector_store, get_zotero_identity
+from backend.services.access_gate import assert_can_access
+from backend.services.zotero_identity import ZoteroIdentity
+```
+
+(There is already a `from typing import Optional` line — merge rather than duplicate; there is already `from backend.dependencies import get_vector_store` — merge into a single import line.)
+
+Change `list_libraries` (currently lines 80-103):
+
+```python
+@router.get("/libraries", response_model=list[LibraryDetailResponse])
+def list_libraries(
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    List libraries known to the backend (indexed or registered), filtered to
+    the caller's own readable targets when authenticated via a Zotero key.
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+
+    settings = get_settings()
+    reg_service = RegistrationService(settings.registrations_path)
+    registrations = reg_service.get_all()
+
+    all_metadata = vector_store.get_all_library_metadata()
+    metadata_by_id = {m.library_id: m for m in all_metadata}
+
+    # Union of all known library IDs (indexed + registered)
+    all_ids = set(metadata_by_id.keys()) | set(registrations.keys())
+    if identity is not None:
+        all_ids &= set(identity.targets)
+
+    return [
+        _build_detail(lid, metadata_by_id.get(lid), registrations.get(lid))
+        for lid in sorted(all_ids)
+    ]
+```
+
+Change `clear_library_index` (currently lines 152-172): add the dependency param and an `assert_can_access` call right after the vector-store-availability check:
+
+```python
+@router.delete("/libraries/{library_id}/index")
+def clear_library_index(
+    library_id: str,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    Remove all indexed data for a library (chunks, dedup records, metadata).
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
+
+    try:
+        chunks_deleted = vector_store.delete_library_chunks(library_id)
+        dedup_deleted = vector_store.delete_library_deduplication_records(library_id)
+        metadata_deleted = vector_store.delete_library_metadata(library_id)
+
+        return {
+            "library_id": library_id,
+            "chunks_deleted": chunks_deleted,
+            "dedup_deleted": dedup_deleted,
+            "metadata_deleted": metadata_deleted,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to clear library index: {str(e)}")
+```
+
+Change `sync_library_deletions` (currently lines 234-270):
+
+```python
+@router.post("/libraries/{library_id}/sync-deletions", response_model=SyncDeletionsResponse)
+def sync_library_deletions(
+    library_id: str,
+    request: SyncDeletionsRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """Remove chunks for indexed items no longer present in the Zotero library.
+
+    Called by the plugin after it has collected the complete set of current Zotero
+    item keys (parent items only, not attachment keys).  Any indexed item whose key
+    is absent from *current_item_keys* is treated as deleted and its chunks and
+    deduplication records are purged.
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
+
+    try:
+        indexed = vector_store.get_all_indexed_item_versions(library_id)
+        current_keys = set(request.current_item_keys)
+        orphaned = set(indexed) - current_keys
+
+        deleted_chunks = 0
+        for key in orphaned:
+            deleted_chunks += vector_store.delete_item_chunks(library_id, key)
+            vector_store.delete_item_deduplication_records(library_id, key)
+
+        if orphaned:
+            logger.info(
+                "sync-deletions: removed %d orphaned item(s) (%d chunks) from library %s",
+                len(orphaned),
+                deleted_chunks,
+                library_id,
+            )
+
+        return SyncDeletionsResponse(deleted_items=len(orphaned), deleted_chunks=deleted_chunks)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"sync-deletions failed: {str(e)}")
+```
+
+Change `clear_item_chunks` (currently lines 273-293):
+
+```python
+@router.delete("/libraries/{library_id}/items/{item_key}/chunks")
+def clear_item_chunks(
+    library_id: str,
+    item_key: str,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    Remove all indexed chunks for a specific item within a library.
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, library_id)
+
+    try:
+        chunks_deleted = vector_store.delete_item_chunks(library_id, item_key)
+        vector_store.delete_item_deduplication_records(library_id, item_key)
+        return {
+            "library_id": library_id,
+            "item_key": item_key,
+            "chunks_deleted": chunks_deleted,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to clear item chunks: {str(e)}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_libraries_api.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Run the full existing suite to confirm no regressions**
+
+Run: `uv run pytest backend/tests -x -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/api/libraries.py backend/tests/test_libraries_api.py
+git commit -m "fix: filter GET /api/libraries and enforce access on delete/sync endpoints"
+```
+
+---
+
+### Task 8: Enforce access on `backend/api/document_upload.py`, remove self-asserted `user_id`
+
+**Files:**
+- Modify: `backend/api/document_upload.py` (imports at ~lines 17-40; delete `_check_registration` at ~lines 247-264; `AbstractIndexRequest` at ~line 239; `upload_and_index_abstract` at ~lines 788-892; `batch_update_metadata` at ~lines 900-950; `_parse_upload_request` at ~lines 958-999; the two call sites at ~lines 594-637 and ~675-693)
+- Test: `backend/tests/test_document_upload_authorization.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Endpoint tests for backend.api.document_upload authorization:
+- batch metadata update, abstract indexing, and file upload all 403 for a
+  library outside the caller's targets
+- user_id is taken from the validated identity, not the request body
+"""
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.db.vector_store import VectorStore
+from backend.services.zotero_identity import ZoteroIdentity, reset_identity_cache
+import backend.dependencies as dependencies
+
+
+class DocumentUploadAuthorizationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        reset_settings()
+        reset_identity_cache()
+        s = get_settings()
+        s.data_path = Path(self.tmp.name)
+        s.testing = True
+        self.client = TestClient(app)
+        app.state.vector_store = VectorStore(
+            storage_path=Path(self.tmp.name) / "qdrant",
+            embedding_dim=8,
+            embedding_model_name="test-model",
+        )
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+        self.tmp.cleanup()
+        reset_settings()
+        reset_identity_cache()
+
+    def _set_identity(self, identity):
+        app.dependency_overrides[dependencies.get_zotero_identity] = lambda: identity
+
+    def test_batch_metadata_update_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/index/items/metadata",
+            json={"library_id": "users/2", "items": []},
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_batch_metadata_update_within_targets_succeeds(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/index/items/metadata",
+            json={"library_id": "users/1", "items": []},
+        )
+        self.assertEqual(r.status_code, 200)
+
+    def test_abstract_index_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        r = self.client.post(
+            "/api/index/abstract",
+            json={
+                "library_id": "users/2",
+                "item_key": "ITEM1",
+                "abstract_text": "word " * 200,
+            },
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_upload_document_outside_targets_is_403(self):
+        self._set_identity(ZoteroIdentity(user_id=1, username="u", targets=["users/1"]))
+        metadata = json.dumps({
+            "library_id": "users/2",
+            "item_key": "ITEM1",
+            "attachment_key": "ATT1",
+        })
+        r = self.client.post(
+            "/api/index/document",
+            files={"file": ("doc.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+            data={"metadata": metadata},
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_upload_document_body_user_id_is_ignored_in_favor_of_identity(self):
+        self._set_identity(ZoteroIdentity(user_id=42, username="real", targets=["users/1"]))
+        metadata = json.dumps({
+            "library_id": "users/1",
+            "item_key": "ITEM1",
+            "attachment_key": "ATT1",
+            "user_id": 999,  # attacker-supplied — must be ignored
+        })
+        r = self.client.post(
+            "/api/index/document",
+            files={"file": ("doc.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+            data={"metadata": metadata},
+        )
+        self.assertNotEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest backend/tests/test_document_upload_authorization.py -v`
+Expected: FAIL on the three 403 tests (200 or a processing error instead of 403); the body-`user_id` test may pass or fail depending on downstream mocks — the important regression check happens in Step 4 after the fix, where we can additionally grep the code to confirm `meta_dict.get("user_id")` is gone from the trust path.
+
+- [ ] **Step 3: Wire enforcement, remove `_check_registration` and the self-asserted `user_id`**
+
+In `backend/api/document_upload.py`, change the import block. Replace:
+
+```python
+from backend.dependencies import get_client_api_keys, get_vector_store, make_embedding_service
+```
+
+with:
+
+```python
+from backend.dependencies import get_client_api_keys, get_vector_store, get_zotero_identity, make_embedding_service
+from backend.services.access_gate import assert_can_access
+from backend.services.zotero_identity import ZoteroIdentity
+```
+
+Remove the now-unused import (it was only used by `_check_registration`, which this task deletes):
+
+```python
+from backend.services.registration_service import RegistrationService
+```
+
+Remove the `user_id` field from `AbstractIndexRequest` (currently line 239):
+
+```python
+class AbstractIndexRequest(BaseModel):
+    """Request to index an item via its abstractNote (no attachment file)."""
+
+    library_id: str
+    library_type: str = "user"
+    item_key: str
+    item_version: int = 0
+    title: Optional[str] = "Untitled"
+    authors: list[str] = []
+    year: Optional[int] = None
+    item_type: Optional[str] = None
+    zotero_modified: str = ""
+    abstract_text: str
+    library_name: str = ""
+```
+
+(i.e. delete the trailing `user_id: Optional[int] = None` line.)
+
+Delete the `_check_registration` function entirely (currently lines 247-264):
+
+```python
+def _check_registration(library_id: str, user_id: Optional[int], settings: Settings) -> None:
+    """Raise 403 if registration is required and the user is not registered.
+
+    Skipped when api_host is localhost/127.0.0.1 or REQUIRE_REGISTRATION=false.
+    """
+    if not settings.require_registration:
+        return
+    if settings.api_host in ("localhost", "127.0.0.1"):
+        return
+    service = RegistrationService(settings.registrations_path)
+    if not service.is_registered(library_id, user_id):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Library not registered for this user. "
+                "Please update the plugin to the newest version."
+            ),
+        )
+```
+
+In `upload_and_index_abstract` (currently lines 788-806), change the signature and the top of the body:
+
+```python
+@router.post(
+    "/index/abstract",
+    response_model=DocumentUploadResult,
+    summary="Index an item via its abstractNote (remote mode, no attachment file)",
+)
+async def upload_and_index_abstract(
+    http_request: Request,
+    request: AbstractIndexRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    Index a Zotero item using its abstractNote when no attachment file is available.
+
+    The abstract is chunked and embedded directly.  A virtual attachment key
+    ``{item_key}:abstract`` is used so the chunks can be tracked independently.
+    The abstract must meet the configured minimum word count (MIN_ABSTRACT_WORDS).
+    """
+    settings = get_settings()
+    assert_can_access(identity, request.library_id)
+    user_id = identity.user_id if identity else None
+    word_count = len(request.abstract_text.split())
+    logger.info(
+        f"Abstract index: library={request.library_id} user={user_id} "
+        f"item={request.item_key} words={word_count}"
+    )
+```
+
+(The rest of the function body is unchanged — it never referenced `request.user_id` again after the log line.)
+
+In `batch_update_metadata` (currently lines 900-913), add the dependency and enforcement:
+
+```python
+@router.post(
+    "/index/items/metadata",
+    response_model=BatchMetadataUpdateResult,
+    summary="Update payload metadata for existing chunks without re-embedding",
+)
+def batch_update_metadata(
+    request: BatchMetadataUpdateRequest,
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    Update bibliographic metadata fields on existing indexed chunks without re-embedding.
+
+    Used by the plugin after check-indexed returns needs_metadata_update=True for items
+    whose schema_version is below the current version (e.g. item_type was added in v3).
+
+    No file bytes are uploaded; the backend calls Qdrant set_payload() directly.
+    """
+    if vector_store is None:
+        raise HTTPException(status_code=503, detail="Vector store is unavailable")
+    assert_can_access(identity, request.library_id)
+```
+
+(The rest of the function body, starting from `updated_items = 0`, is unchanged.)
+
+Change `_parse_upload_request` (currently lines 958-999) to accept and use the identity:
+
+```python
+async def _parse_upload_request(file: UploadFile, metadata: str, identity: Optional[ZoteroIdentity]):
+    """Parse and validate the common multipart upload fields.
+
+    Returns a tuple of all parsed fields needed by both sync and async endpoints.
+    Raises HTTPException 400 on validation errors, 403 if library_id is
+    outside identity's readable targets (see access_gate.assert_can_access).
+    """
+    try:
+        meta_dict = json.loads(metadata)
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid metadata JSON: {e}")
+
+    required = {"library_id", "item_key", "attachment_key"}
+    missing = required - meta_dict.keys()
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing required metadata fields: {sorted(missing)}",
+        )
+
+    library_id: str = meta_dict["library_id"]
+    item_key: str = meta_dict["item_key"]
+    attachment_key: str = meta_dict["attachment_key"]
+    assert_can_access(identity, library_id)
+    user_id: Optional[int] = identity.user_id if identity else meta_dict.get("user_id")
+    library_type: str = meta_dict.get("library_type", "user")
+    mime_type: str = meta_dict.get("mime_type", "application/pdf")
+    item_version: int = int(meta_dict.get("item_version", 0))
+    attachment_version: int = int(meta_dict.get("attachment_version", 0))
+    item_modified: str = meta_dict.get(
+        "zotero_modified", datetime.now(timezone.utc).isoformat()
+    )
+
+    doc_metadata = DocumentMetadata(
+        library_id=library_id,
+        item_key=item_key,
+        attachment_key=attachment_key,
+        title=meta_dict.get("title", "Untitled"),
+        authors=meta_dict.get("authors", []),
+        year=meta_dict.get("year"),
+        item_type=meta_dict.get("item_type"),
+    )
+```
+
+(Everything after this point in `_parse_upload_request` — reading the file bytes and returning the tuple — is unchanged.)
+
+Update the two call sites. In `upload_and_index_document` (currently lines 594-637 area), add the dependency to the function signature and pass it through:
+
+```python
+    file: UploadFile = File(..., description="Raw attachment bytes"),
+    metadata: str = Form(
+        ...,
+        description=(
+            "JSON string with fields: library_id, library_type, item_key, "
+            "attachment_key, mime_type, item_version, attachment_version, "
+            "title, authors (array), year, item_type, "
+            "zotero_modified (ISO 8601 string)"
+        ),
+    ),
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+```
+
+and change the call:
+
+```python
+    meta_dict, doc_metadata, library_id, item_key, attachment_key, user_id, \
+        library_type, mime_type, item_version, attachment_version, item_modified, \
+        file_bytes = await _parse_upload_request(file, metadata, identity)
+```
+
+In `upload_and_index_document_async` (currently lines 675-693 area), add the same dependency and pass it through:
+
+```python
+async def upload_and_index_document_async(
+    http_request: Request,
+    file: UploadFile = File(..., description="Raw attachment bytes"),
+    metadata: str = Form(...),
+    identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity),
+    vector_store: VectorStore = Depends(get_vector_store),
+):
+    """
+    ...unchanged docstring...
+    """
+    meta_dict, doc_metadata, library_id, item_key, attachment_key, user_id, \
+        library_type, mime_type, item_version, attachment_version, item_modified, \
+        file_bytes = await _parse_upload_request(file, metadata, identity)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest backend/tests/test_document_upload_authorization.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Run the full existing suite to confirm no regressions**
+
+Run: `uv run pytest backend/tests -x -q`
+Expected: PASS. `backend/tests/test_async_upload.py` and `backend/tests/test_upload_and_batching.py` call the upload endpoints without any identity override, so `get_zotero_identity` returns `None` (loopback default), taking the same no-op path `_check_registration` used to take for loopback — no behavior change for them. Neither file references `user_id` (confirmed via `grep -n "user_id" backend/tests/test_async_upload.py backend/tests/test_upload_and_batching.py` returning no matches), so removing the `AbstractIndexRequest.user_id` field cannot break them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/api/document_upload.py backend/tests/test_document_upload_authorization.py
+git commit -m "fix: enforce per-library access on upload/index endpoints, stop trusting body user_id"
+```
+
+---
+
+### Task 9: Document the new environment variables
+
+**Files:**
+- Modify: `.env.dist` (insert a new section after "Registration", currently ending around line 53)
+
+- [ ] **Step 1: Add the new section**
+
+Insert after the `# REQUIRE_REGISTRATION=true` line and its blank line (currently line 53-54), before the "Document extraction backend" comment block:
+
+```
+# =============================================================================
+# Access Control (Zotero-key authentication)
+# =============================================================================
+
+# Loopback deployments (API_HOST unset or localhost/127.0.0.1) need none of
+# this: there is exactly one trusted local user and no Zotero-key auth is
+# required at all.
+#
+# Every other deployment authenticates each request with the caller's own
+# read-only Zotero API key (sent by the plugin as X-Zotero-API-Key) and then
+# checks it against an access gate below — a valid Zotero key alone is NOT
+# enough, since any Zotero.org account could otherwise use your server.
+# At least one of AUTHORIZED_GROUP_ID / AUTHORIZED_USER_IDS is REQUIRED for a
+# non-loopback deployment; the server refuses to start without one.
+
+# Zotero group ID that gates access. A caller is authorized if their key
+# grants read access to this group (i.e. they are a member of it). Manage
+# membership entirely on zotero.org — no redeploy needed to add/remove users.
+# AUTHORIZED_GROUP_ID=998877
+
+# Explicit allowlist of Zotero user IDs, in addition to AUTHORIZED_GROUP_ID
+# (OR semantics). Comma-separated. Useful as a fallback or for a small fixed
+# team without a dedicated Zotero group.
+# AUTHORIZED_USER_IDS=39226,123456
+
+# Legacy shared secret, kept only for the transitional migration window while
+# users upgrade to a plugin version that sends X-Zotero-API-Key. A request
+# presenting this key bypasses per-library authorization entirely (the same
+# way ALL requests did before this feature) — do not treat it as a
+# long-term deployment mode for a multi-user instance. See
+# docs/history/plan-zotero-key-auth.md Part 5.
+# API_KEY=your_shared_secret
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.dist
+git commit -m "docs: document AUTHORIZED_GROUP_ID / AUTHORIZED_USER_IDS in .env.dist"
+```
+
+---
+
+### Task 10: Full suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full backend suite**
+
+Run: `uv run pytest backend/tests -q`
+Expected: All tests pass, including every test file created in Tasks 1-8.
+
+- [ ] **Step 2: Run the container smoke test if this branch touched `backend/main.py` or `backend/dependencies.py` (it did)**
+
+Run: `uv run pytest -m container -v -s`
+Expected: PASS, or SKIPPED if neither podman nor docker is available in the current environment. Per `CLAUDE.md`, this is required after any change to `backend/main.py`/`backend/dependencies.py`.
+
+- [ ] **Step 3: Manually sanity-check the fail-closed startup guard**
+
+Run:
+```bash
+API_HOST=rag.example.com uv run python -c "from backend.main import app"
+```
+Expected: raises `RuntimeError: Refusing to start in remote mode (api_host='rag.example.com') without an access gate: ...` — confirming the guard is live for a real process start, not just in unit tests where settings are mutated after import.
+
+Then confirm it starts cleanly with the gate configured:
+```bash
+API_HOST=rag.example.com AUTHORIZED_GROUP_ID=1 uv run python -c "from backend.main import app; print('OK')"
+```
+Expected: prints `OK`.
+
+- [ ] **Step 4: No commit for this task** — it is verification-only. If Step 3 reveals a problem, fix it in the relevant earlier task's files and re-commit there (or as a small follow-up commit), then re-run Step 1.
+
+---
+
+## Deliberately deferred to a follow-up plan
+
+- **Plugin setup wizard** (design doc Part 3): sending `X-Zotero-API-Key` from the plugin, the "create a key on zotero.org" UI flow, and the `POST /api/auth/validate` convenience endpoint the wizard would call. Needs a place to test against — do this once this plan's endpoints exist on a real deployment or local server.
+- **Migration cutover** (design doc Part 5, steps 3-4): announcing the change, monitoring the "legacy shared API_KEY" warning log to see when it's safe, and removing the legacy fallback branch from `resolve_zotero_identity`. Depends on the plugin wizard shipping first.
+- **`GET /api/libraries/{id}/status`, `GET /api/libraries/{id}/index-status`, `POST /api/libraries/{id}/reconcile-count`**: not named in the vulnerability report or the design doc's Part 1.2 table; left unfiltered for now (see the "Explicitly out of scope" note at the top of this plan).
+- **`docs/history/master.md` phase-summary entry**: once this plan and its follow-up are both executed, add the short summary + link per `CLAUDE.md`'s "Implementation progress documentation" convention — appropriate once there's a complete phase to summarize, not mid-plan.

--- a/docs/superpowers/plans/2026-07-06-zotero-key-auth-plugin-wizard.md
+++ b/docs/superpowers/plans/2026-07-06-zotero-key-auth-plugin-wizard.md
@@ -1,0 +1,1662 @@
+# Zotero Key Auth: Plugin Wizard + Backend Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch the plugin from the legacy shared `X-API-Key` to a personal Zotero API key
+(`X-Zotero-API-Key`), add a setup wizard to obtain/validate that key and the service API keys,
+simplify auto-indexing to a single on/off toggle, and remove the backend's now-unneeded
+transitional shared-secret fallback.
+
+**Architecture:** Two independent slices that share one contract (`X-Zotero-API-Key` +
+`GET /api/auth/whoami`): (1) a small backend change — delete the legacy fallback branch in
+`resolve_zotero_identity`, add `GET /api/auth/whoami` which just reads back the identity the
+existing auth middleware already resolved; (2) plugin changes — rename the stored credential,
+rebuild two Preferences sections, and add a new 3-step dialog (`setup-wizard.xhtml`/`.js`) modeled
+directly on the existing `fix-unavailable.xhtml`/`.js` dialog pattern.
+
+**Tech Stack:** FastAPI + pydantic-settings + unittest/TestClient (backend); vanilla JS + XUL/HTML
+hybrid XHTML dialogs, Zotero.Prefs, `Services.scriptloader.loadSubScript` (plugin). No JS test
+harness exists in this repo (`plugin/test/` referenced in CLAUDE.md as an aspirational convention
+does not exist yet) — plugin verification in this plan is manual, via the `verify` skill, not a
+new automated harness (out of scope; would be a disproportionate side-project).
+
+Design doc: `docs/superpowers/specs/2026-07-06-zotero-key-auth-plugin-wizard-design.md`.
+Prior design doc (Parts 1–2, already implemented on this branch):
+`docs/history/plan-zotero-key-auth.md`.
+
+---
+
+## Task 1: Backend — remove the legacy shared-secret fallback
+
+**Files:**
+- Modify: `backend/config/settings.py:34-42`
+- Modify: `backend/dependencies.py:25-60`
+- Modify: `backend/main.py:150-166`
+- Modify: `.env.dist:71-76`
+- Modify: `docker-compose.yml` (the `API_KEY` line, currently around line 69)
+- Modify (tests): `backend/tests/test_resolve_zotero_identity.py`
+- Modify (tests): `backend/tests/test_main_auth_middleware.py`
+- Modify (tests): `backend/tests/test_autoindex_api.py:22`
+
+- [ ] **Step 1: Remove the 3 legacy-fallback tests and add one confirming the fallback is gone**
+
+In `backend/tests/test_resolve_zotero_identity.py`, delete these three test methods entirely:
+`test_legacy_shared_key_accepted_as_transitional_fallback`, `test_legacy_key_via_query_param_accepted`,
+`test_wrong_legacy_key_rejected` (they reference `s.api_key`, which this plan removes from
+`Settings`).
+
+Replace them with a single test confirming the old header alone no longer authenticates:
+
+```python
+    def test_legacy_shared_key_no_longer_accepted(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/probe", headers={"X-API-Key": "SHARED"})
+        self.assertEqual(r.status_code, 401)
+```
+
+Add it right after `test_remote_missing_key_rejected` (which it parallels).
+
+- [ ] **Step 2: Run the test file to verify the new test fails for the right reason**
+
+Run: `uv run pytest backend/tests/test_resolve_zotero_identity.py -v`
+
+Expected: `test_legacy_shared_key_no_longer_accepted` FAILS (currently the `X-API-Key` header still
+authenticates via the legacy branch, so today's response is 200, not 401). The removed tests are
+gone, no collection errors.
+
+- [ ] **Step 3: Remove the legacy fallback branch in `resolve_zotero_identity`**
+
+In `backend/dependencies.py`, replace lines 44-50:
+
+```python
+    zotero_key = request.headers.get("X-Zotero-API-Key")
+    if not zotero_key:
+        legacy_key = request.headers.get("X-API-Key") or request.query_params.get("api_key")
+        if settings.api_key and legacy_key == settings.api_key:
+            logger.warning("Request authenticated via legacy shared API_KEY (transitional path)")
+            return None
+        raise HTTPException(status_code=401, detail="Missing X-Zotero-API-Key header.")
+```
+
+with:
+
+```python
+    zotero_key = request.headers.get("X-Zotero-API-Key")
+    if not zotero_key:
+        raise HTTPException(status_code=401, detail="Missing X-Zotero-API-Key header.")
+```
+
+Also update the function's docstring (lines 26-38) to drop the "transitional legacy-shared-key
+path" mention:
+
+```python
+async def resolve_zotero_identity(request: Request) -> Optional[ZoteroIdentity]:
+    """Resolve and gate the caller's Zotero identity for the current request.
+
+    Returns None for the loopback no-auth path (Part 4) — single trusted local
+    user, no per-library enforcement needed (see access_gate.assert_can_access()).
+    Raises HTTPException: 401 for a missing/invalid/revoked key, 403 if the
+    Part 2 gate rejects an otherwise-valid identity, 503 if zotero.org is
+    unreachable with no cached validation to fall back on.
+
+    Called once per request by the auth middleware in backend/main.py, which
+    stashes the result on request.state.zotero_identity for every /api/*
+    request. Route handlers should depend on get_zotero_identity instead,
+    not this function directly, to avoid re-validating the key a second time.
+    """
+```
+
+- [ ] **Step 4: Remove the `api_key` field from `Settings`**
+
+In `backend/config/settings.py`, delete lines 37-42:
+
+```python
+    api_key: Optional[str] = Field(
+        default=None,
+        description="API key for remote access (X-API-Key header). "
+                    "When set, all requests must include this key. "
+                    "Leave unset for local-only deployments."
+    )
+```
+
+(leave `api_host`, `api_port`, and `public_libraries_config` where they are — only the `api_key`
+field block is removed).
+
+- [ ] **Step 5: Remove the now-dead `s.api_key` line in the autoindex test**
+
+In `backend/tests/test_autoindex_api.py:22`, delete the line:
+
+```python
+        s.api_key = None  # disable auth middleware for the test
+```
+
+(it was already a no-op comment on a loopback-default test — `api_host` defaults to `localhost`,
+which already skips auth entirely regardless of `api_key`).
+
+- [ ] **Step 6: Update `test_main_auth_middleware.py`**
+
+Delete the `test_remote_with_legacy_shared_key_still_works` method (lines 64-70) from
+`backend/tests/test_main_auth_middleware.py`. Update the module docstring's mention of "Response
+*content* filtering is covered later" is unrelated and can stay; no other change needed in this
+file.
+
+- [ ] **Step 7: Update `api_key_middleware`'s docstring in `backend/main.py`**
+
+Replace the docstring at `backend/main.py:152-166`:
+
+```python
+async def api_key_middleware(request: Request, call_next):
+    """Resolve and gate the caller's Zotero identity for every /api/* request.
+
+    Loopback deployments (api_host in {localhost, 127.0.0.1}) skip this
+    entirely (Part 4) — there is exactly one trusted local user. Everywhere
+    else the caller must present a valid, gate-approved Zotero API key
+    (X-Zotero-API-Key). The resolved identity (or None for loopback) is
+    stashed on request.state.zotero_identity so downstream route dependencies
+    (backend.dependencies.get_zotero_identity) don't re-validate.
+
+    OPTIONS requests (CORS preflight) are always allowed so the browser can
+    complete the preflight handshake.
+    """
+```
+
+- [ ] **Step 8: Run the full backend auth test suite to verify everything passes**
+
+Run: `uv run pytest backend/tests/test_resolve_zotero_identity.py backend/tests/test_main_auth_middleware.py backend/tests/test_autoindex_api.py -v`
+
+Expected: all PASS, including the new `test_legacy_shared_key_no_longer_accepted`.
+
+- [ ] **Step 9: Remove `API_KEY` from `.env.dist` and `docker-compose.yml`**
+
+In `.env.dist`, delete lines 71-76 (the "Legacy shared secret..." comment block and the
+`# API_KEY=your_shared_secret` line), leaving the blank line before `# Document extraction
+backend.` intact.
+
+In `docker-compose.yml`, delete the two lines:
+
+```yaml
+      # set a secret api key for a real deployment!
+      API_KEY: ${API_KEY:-}
+```
+
+(the field no longer exists on `Settings`; `extra="ignore"` in `SettingsConfigDict` means leaving
+a stray env var wouldn't break anything, but keeping it would be actively misleading to an
+operator reading the compose file).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/config/settings.py backend/dependencies.py backend/main.py \
+        backend/tests/test_resolve_zotero_identity.py backend/tests/test_main_auth_middleware.py \
+        backend/tests/test_autoindex_api.py .env.dist docker-compose.yml
+git commit -m "fix: remove transitional legacy shared-secret auth fallback
+
+Zotero-key auth is now the only non-loopback auth path — no plugin
+still depends on X-API-Key, so the transitional fallback from the
+zotero-key-auth-backend migration is no longer needed."
+```
+
+---
+
+## Task 2: Backend — add `GET /api/auth/whoami`
+
+**Files:**
+- Create: `backend/api/auth.py`
+- Modify: `backend/main.py:11,190-198` (import + router registration)
+- Create: `backend/tests/test_auth_whoami.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_auth_whoami.py`:
+
+```python
+"""Tests for GET /api/auth/whoami — used by the plugin's Preferences pane and
+setup wizard to validate a Zotero API key and show the caller's identity."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.config.settings import get_settings, reset_settings
+from backend.services.zotero_identity import reset_identity_cache
+from backend.zotero.key_validator import KeyValidation
+
+
+class AuthWhoamiTest(unittest.TestCase):
+    def setUp(self):
+        reset_settings()
+        reset_identity_cache()
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        reset_settings()
+        reset_identity_cache()
+
+    def test_loopback_reports_loopback_true(self):
+        r = self.client.get("/api/auth/whoami")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"authorized": True, "loopback": True})
+
+    def test_remote_valid_gated_key_returns_identity(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="alice", targets=["users/1", "groups/999"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/api/auth/whoami", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {
+            "authorized": True,
+            "loopback": False,
+            "user_id": 1,
+            "username": "alice",
+            "targets": ["users/1", "groups/999"],
+        })
+
+    def test_remote_missing_key_is_401(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        r = self.client.get("/api/auth/whoami")
+        self.assertEqual(r.status_code, 401)
+
+    def test_remote_ungated_key_is_403(self):
+        s = get_settings()
+        s.api_host = "rag.example.com"
+        s.authorized_group_id = 999
+        validation = KeyValidation(user_id=1, username="alice", targets=["users/1"], read_only=True)
+        with patch("backend.services.zotero_identity.validate_key", new=AsyncMock(return_value=validation)):
+            r = self.client.get("/api/auth/whoami", headers={"X-Zotero-API-Key": "KEY"})
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest backend/tests/test_auth_whoami.py -v`
+
+Expected: FAIL with `404 Not Found` on every request (no `/api/auth/whoami` route registered yet).
+
+- [ ] **Step 3: Create `backend/api/auth.py`**
+
+```python
+"""Identity-check endpoint used by the plugin's Preferences pane and setup
+wizard to validate a Zotero API key before/without saving it, and to show
+the caller which libraries their key can access.
+
+Deliberately thin: all the validation, caching, and gate logic already runs
+in the auth middleware (backend.dependencies.resolve_zotero_identity) for
+every /api/* request. This handler only reads back the result — a 401/403/503
+never reaches it, the middleware already returned that response.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+
+from backend.dependencies import get_zotero_identity
+from backend.services.zotero_identity import ZoteroIdentity
+
+router = APIRouter()
+
+
+@router.get("/auth/whoami", summary="Validate the caller's Zotero API key and return their identity")
+def whoami(identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity)) -> dict:
+    if identity is None:
+        return {"authorized": True, "loopback": True}
+    return {
+        "authorized": True,
+        "loopback": False,
+        "user_id": identity.user_id,
+        "username": identity.username,
+        "targets": identity.targets,
+    }
+```
+
+- [ ] **Step 4: Register the router in `backend/main.py`**
+
+Add `auth` to the import at `backend/main.py:16`:
+
+```python
+from backend.api import config, libraries, indexing, query, document_upload, registration, rate_limits, public_query, autoindex, auth
+```
+
+Add the include next to the other routers, after line 198 (`app.include_router(autoindex.router, ...)`):
+
+```python
+app.include_router(auth.router, prefix="/api", tags=["auth"])
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `uv run pytest backend/tests/test_auth_whoami.py -v`
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 6: Run the full backend suite**
+
+Run: `uv run pytest backend/tests/ -v`
+
+Expected: all PASS (no regressions from Task 1 or 2).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/api/auth.py backend/main.py backend/tests/test_auth_whoami.py
+git commit -m "feat: add GET /api/auth/whoami for plugin key validation"
+```
+
+---
+
+## Task 3: Plugin — rename `apiKey` to `zoteroApiKey`, switch header, add identity/loopback helpers
+
+**Files:**
+- Modify: `plugin/src/zotero-rag.js:106-107,172,206-230,440-464,488-503`
+
+- [ ] **Step 1: Rename the stored credential and its pref**
+
+In the constructor (`plugin/src/zotero-rag.js:106-107`), replace:
+
+```js
+		/** @type {string} */
+		this.apiKey = '';
+```
+
+with:
+
+```js
+		/** @type {string} */
+		this.zoteroApiKey = '';
+
+		/** @type {boolean} */
+		this._wizardAutoLaunchedThisSession = false;
+```
+
+In `init()` (`plugin/src/zotero-rag.js:172`), replace:
+
+```js
+		// Load optional API key (required when backend is on a remote host)
+		this.apiKey = Zotero.Prefs.get('extensions.zotero-rag.apiKey', true) || '';
+```
+
+with:
+
+```js
+		// Load the personal Zotero API key (required when backend is on a remote host)
+		this.zoteroApiKey = Zotero.Prefs.get('extensions.zotero-rag.zoteroApiKey', true) || '';
+```
+
+- [ ] **Step 2: Switch the auth header and delete the unused query-param helper**
+
+Replace `getAuthHeaders()` and delete `addApiKeyParam()` (`plugin/src/zotero-rag.js:200-230`):
+
+```js
+	/**
+	 * Return HTTP headers to include in all backend requests.
+	 * Adds X-Zotero-API-Key when a personal Zotero API key is configured.
+	 * @param {Record<string, string>} [extra] - Additional headers to merge
+	 * @returns {Record<string, string>}
+	 */
+	getAuthHeaders(extra = {}) {
+		/** @type {Record<string, string>} */
+		const headers = { ...extra };
+		if (this.zoteroApiKey) {
+			headers['X-Zotero-API-Key'] = this.zoteroApiKey;
+		}
+		// Include any service API keys the user has configured
+		for (const keyInfo of this.requiredApiKeys) {
+			const value = Zotero.Prefs.get(`extensions.zotero-rag.serviceApiKey.${keyInfo.key_name}`, true) || '';
+			headers[keyInfo.header_name] = value;
+		}
+		return headers;
+	}
+
+	/**
+	 * True if the configured backend URL points at a loopback address, where
+	 * the backend skips Zotero-key auth entirely (single trusted local user).
+	 * @returns {boolean}
+	 */
+	isLoopbackBackend() {
+		try {
+			const host = new URL(this.backendURL).hostname;
+			return host === 'localhost' || host === '127.0.0.1';
+		} catch (_) {
+			return false;
+		}
+	}
+
+	/**
+	 * Validate a Zotero API key against the backend and return the caller's
+	 * identity. Does not read or write any pref — callers pass the candidate
+	 * key explicitly so it can be checked before being saved.
+	 * @param {string} candidateKey
+	 * @returns {Promise<{authorized: true, loopback: boolean, user_id?: number, username?: string, targets?: string[]}>}
+	 * @throws {Error} with a `status` property set to the HTTP status code, and
+	 *   a message taken from the response's `detail` field, on 401/403/503.
+	 */
+	async checkZoteroIdentity(candidateKey) {
+		const response = await fetch(`${this.backendURL}/api/auth/whoami`, {
+			headers: candidateKey ? { 'X-Zotero-API-Key': candidateKey } : {},
+		});
+		if (!response.ok) {
+			const body = await response.json().catch(() => ({}));
+			const err = /** @type {Error & {status?: number}} */ (new Error(body.detail || `HTTP ${response.status}`));
+			err.status = response.status;
+			throw err;
+		}
+		return response.json();
+	}
+```
+
+- [ ] **Step 3: Preserve the HTTP status code on `checkBackendVersion()` failures**
+
+Replace `checkBackendVersion()` (`plugin/src/zotero-rag.js:440-464`):
+
+```js
+	/**
+	 * Check backend version for compatibility.
+	 * @returns {Promise<string>} Backend version string
+	 * @throws {Error & {status?: number}} If backend is not reachable or returns error.
+	 *   `status` is set to the HTTP status code when the server responded (e.g. 401/403),
+	 *   and left undefined for network-level failures (server unreachable).
+	 */
+	async checkBackendVersion() {
+		if (!this.backendURL) {
+			throw new Error('Backend URL not configured');
+		}
+
+		let response;
+		try {
+			response = await fetch(`${this.backendURL}/api/version`, {
+				headers: this.getAuthHeaders()
+			});
+		} catch (e) {
+			const errorMessage = e instanceof Error ? e.message : String(e);
+			throw new Error(`Failed to check backend version: ${errorMessage}`);
+		}
+		if (!response.ok) {
+			const body = await response.json().catch(() => ({}));
+			const err = /** @type {Error & {status?: number}} */ (
+				new Error(`GET /api/version: HTTP ${response.status}${body.detail ? ` — ${body.detail}` : ''}`)
+			);
+			err.status = response.status;
+			throw err;
+		}
+		const data = /** @type {BackendVersion} */ (await response.json());
+		this.log(`Backend version: ${data.api_version}`);
+
+		// TODO: Add version compatibility checking
+		// Refresh the list of required API keys from the server
+		await this.fetchRequiredApiKeys();
+		return data.api_version;
+	}
+```
+
+- [ ] **Step 4: Update `fetchRequiredApiKeys()`'s header**
+
+In `plugin/src/zotero-rag.js:488-503`, replace:
+
+```js
+			const resp = await fetch(`${this.backendURL}/api/required-keys`, {
+				headers: {
+					'Content-Type': 'application/json',
+					...(this.apiKey ? { 'X-API-Key': this.apiKey } : {}),
+				},
+			});
+```
+
+with:
+
+```js
+			const resp = await fetch(`${this.backendURL}/api/required-keys`, {
+				headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
+			});
+```
+
+- [ ] **Step 5: Verify no remaining references to the old credential**
+
+Run: `grep -n "\.apiKey\b\|extensions.zotero-rag.apiKey\b\|X-API-Key\|addApiKeyParam" plugin/src/zotero-rag.js`
+
+Expected: no output (all occurrences renamed/removed). Service API keys use
+`extensions.zotero-rag.serviceApiKey.*`, a different pref namespace — unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugin/src/zotero-rag.js
+git commit -m "feat: switch plugin auth from shared X-API-Key to personal Zotero API key"
+```
+
+---
+
+## Task 4: Plugin — extract the Service API Keys renderer into a shared helper
+
+The wizard's Step 3 needs the exact same dynamic Service API Keys UI that `preferences.js`
+already builds inline. Extract it once so neither file duplicates the DOM-building logic.
+
+**Files:**
+- Modify: `plugin/src/zotero-rag.js` (add new method)
+- Modify: `plugin/src/preferences.js:64-133` (use the extracted method)
+
+- [ ] **Step 1: Add `renderServiceApiKeyFields()` to `zotero-rag.js`**
+
+Add this method to the `ZoteroRAGPlugin` class in `plugin/src/zotero-rag.js` (near
+`fetchRequiredApiKeys`, e.g. directly after it):
+
+```js
+	/**
+	 * Render service API key input fields into `container`, one row + description
+	 * per required key, each bound to `extensions.zotero-rag.serviceApiKey.<key_name>`.
+	 * Shared between the Preferences pane and the setup wizard so both stay in sync.
+	 * @param {Document} doc
+	 * @param {HTMLElement} container - Element to render rows into (existing dynamic rows are cleared first)
+	 * @param {HTMLElement|null} placeholder - Shown/hidden depending on whether requiredKeys is empty
+	 * @param {Array<{key_name: string, header_name: string, description: string, docs_url?: string|null, required_for: string[]}>} requiredKeys
+	 * @returns {void}
+	 */
+	renderServiceApiKeyFields(doc, container, placeholder, requiredKeys) {
+		if (!container) return;
+
+		container.querySelectorAll('.service-key-row, .service-key-desc').forEach(el => el.remove());
+
+		if (!requiredKeys || requiredKeys.length === 0) {
+			if (placeholder) placeholder.style.display = '';
+			return;
+		}
+		if (placeholder) placeholder.style.display = 'none';
+
+		for (const keyInfo of requiredKeys) {
+			const prefKey = `extensions.zotero-rag.serviceApiKey.${keyInfo.key_name}`;
+			const storedValue = Zotero.Prefs.get(prefKey, true) || '';
+
+			const row = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+			row.className = 'setting-row service-key-row';
+
+			const label = doc.createElementNS('http://www.w3.org/1999/xhtml', 'label');
+			label.textContent = `${keyInfo.key_name}:`;
+			label.setAttribute('for', `zotero-rag-key-${keyInfo.key_name}`);
+
+			const input = /** @type {HTMLInputElement} */ (doc.createElementNS('http://www.w3.org/1999/xhtml', 'input'));
+			input.type = 'password';
+			input.id = `zotero-rag-key-${keyInfo.key_name}`;
+			input.className = 'setting-input';
+			input.value = storedValue;
+			input.placeholder = 'Enter API key';
+			input.addEventListener('change', (e) => {
+				Zotero.Prefs.set(prefKey, /** @type {HTMLInputElement} */ (e.target).value, true);
+			});
+
+			row.appendChild(label);
+			row.appendChild(input);
+			container.appendChild(row);
+
+			if (keyInfo.description) {
+				const desc = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+				desc.className = 'setting-description service-key-desc';
+				desc.textContent = `${keyInfo.description} (used for: ${keyInfo.required_for.join(', ')})`;
+				if (keyInfo.docs_url && /^https?:\/\//i.test(keyInfo.docs_url)) {
+					desc.appendChild(doc.createTextNode(' '));
+					const link = doc.createElementNS('http://www.w3.org/1999/xhtml', 'a');
+					link.setAttribute('href', keyInfo.docs_url);
+					link.setAttribute('target', '_blank');
+					link.textContent = 'Get key';
+					desc.appendChild(link);
+				}
+				container.appendChild(desc);
+			}
+		}
+	}
+```
+
+- [ ] **Step 2: Use it from `preferences.js`**
+
+In `plugin/src/preferences.js`, delete the local `renderApiKeyFields` closure (lines 64-124) and
+replace its two call sites and definition with a call to the shared method. Replace lines 64-133:
+
+```js
+	/**
+	 * Render service API key input fields from the given list.
+	 * @param {Array<{key_name: string, header_name: string, description: string, docs_url?: string|null, required_for: string[]}>} requiredKeys
+	 */
+	const renderApiKeyFields = (requiredKeys) => {
+		const container = doc.getElementById('zotero-rag-service-keys-container');
+		const placeholder = doc.getElementById('zotero-rag-service-keys-placeholder');
+		if (!container) return;
+
+		// Remove previously rendered dynamic rows
+		container.querySelectorAll('.service-key-row, .service-key-desc').forEach(el => el.remove());
+
+		if (!requiredKeys || requiredKeys.length === 0) {
+			if (placeholder) placeholder.style.display = '';
+			return;
+		}
+		if (placeholder) placeholder.style.display = 'none';
+
+		for (const keyInfo of requiredKeys) {
+			const prefKey = `extensions.zotero-rag.serviceApiKey.${keyInfo.key_name}`;
+			const storedValue = Zotero.Prefs.get(prefKey, true) || '';
+
+			const row = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+			row.className = 'setting-row service-key-row';
+
+			const label = doc.createElementNS('http://www.w3.org/1999/xhtml', 'label');
+			label.textContent = `${keyInfo.key_name}:`;
+			label.setAttribute('for', `zotero-rag-key-${keyInfo.key_name}`);
+
+			const input = /** @type {HTMLInputElement} */ (doc.createElementNS('http://www.w3.org/1999/xhtml', 'input'));
+			input.type = 'password';
+			input.id = `zotero-rag-key-${keyInfo.key_name}`;
+			input.className = 'setting-input';
+			input.value = storedValue;
+			input.placeholder = 'Enter API key';
+			input.addEventListener('change', (e) => {
+				Zotero.Prefs.set(prefKey, /** @type {HTMLInputElement} */ (e.target).value, true);
+			});
+
+			row.appendChild(label);
+			row.appendChild(input);
+			container.appendChild(row);
+
+			if (keyInfo.description) {
+				const desc = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+				desc.className = 'setting-description service-key-desc';
+				desc.textContent = `${keyInfo.description} (used for: ${keyInfo.required_for.join(', ')})`;
+				// Link to the provider portal where the key can be created/managed.
+				// Clicks are routed to the system browser by the pane-wide handler above.
+				if (keyInfo.docs_url && /^https?:\/\//i.test(keyInfo.docs_url)) {
+					desc.appendChild(doc.createTextNode(' '));
+					const link = doc.createElementNS('http://www.w3.org/1999/xhtml', 'a');
+					link.setAttribute('href', keyInfo.docs_url);
+					link.setAttribute('target', '_blank');
+					link.textContent = 'Get key';
+					desc.appendChild(link);
+				}
+				container.appendChild(desc);
+			}
+		}
+	};
+
+	// Render from cache immediately so fields appear without needing a server round-trip
+	try {
+		const cached = Zotero.Prefs.get('extensions.zotero-rag.requiredApiKeys', true) || '[]';
+		renderApiKeyFields(JSON.parse(cached));
+	} catch (_) {}
+
+	// Refresh from server in background and re-render if the list has changed
+	this.fetchRequiredApiKeys().then(() => renderApiKeyFields(this.requiredApiKeys));
+```
+
+with:
+
+```js
+	const serviceKeysContainer = doc.getElementById('zotero-rag-service-keys-container');
+	const serviceKeysPlaceholder = doc.getElementById('zotero-rag-service-keys-placeholder');
+
+	// Render from cache immediately so fields appear without needing a server round-trip
+	try {
+		const cached = Zotero.Prefs.get('extensions.zotero-rag.requiredApiKeys', true) || '[]';
+		this.renderServiceApiKeyFields(doc, serviceKeysContainer, serviceKeysPlaceholder, JSON.parse(cached));
+	} catch (_) {}
+
+	// Refresh from server in background and re-render if the list has changed
+	this.fetchRequiredApiKeys().then(() =>
+		this.renderServiceApiKeyFields(doc, serviceKeysContainer, serviceKeysPlaceholder, this.requiredApiKeys)
+	);
+```
+
+- [ ] **Step 3: Manually verify no syntax errors**
+
+Run: `node --check plugin/src/preferences.js && node --check plugin/src/zotero-rag.js`
+
+Expected: no output (both parse cleanly as JS — this is a syntax-only check; Zotero-global calls
+like `Zotero.Prefs` aren't executed by `node --check`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/src/zotero-rag.js plugin/src/preferences.js
+git commit -m "refactor: extract renderServiceApiKeyFields for reuse by the setup wizard"
+```
+
+---
+
+## Task 5: Plugin — Preferences markup: Zotero API Key field, wizard button, auto-index checkbox
+
+**Files:**
+- Modify: `plugin/src/preferences.xhtml:12-78`
+- Modify: `plugin/src/preferences.css` (append)
+
+- [ ] **Step 1: Replace the Backend Server and Automatic indexing sections**
+
+In `plugin/src/preferences.xhtml`, replace lines 12-78 (from `<!-- Backend Settings -->` through
+the closing `</html:fieldset>` of the Automatic indexing section) with:
+
+```xml
+  <!-- Backend Settings -->
+  <html:fieldset class="settings-group">
+    <html:legend>Backend Server</html:legend>
+
+    <html:div class="setting-row">
+      <html:label for="zotero-rag-backend-url">Server URL:</html:label>
+      <html:input id="zotero-rag-backend-url"
+                  type="text"
+                  placeholder="http://localhost:8119"
+                  class="setting-input"/>
+    </html:div>
+
+    <html:div class="setting-description">
+      Connects the plugin to the indexing and search service.
+    </html:div>
+
+    <html:div class="setting-row">
+      <html:label for="zotero-rag-zotero-api-key">Zotero API Key:</html:label>
+      <html:input id="zotero-rag-zotero-api-key"
+                  type="password"
+                  placeholder="Your personal Zotero API key"
+                  class="setting-input"/>
+    </html:div>
+
+    <html:div class="setting-description">
+      Your personal <html:a href="https://www.zotero.org/settings/keys"
+                            target="_blank">Zotero API key</html:a>
+      — used to authenticate you to the server and determine which libraries you can access.
+      Not required when the server runs on your own machine (localhost).
+    </html:div>
+
+    <html:div class="setting-description" id="zotero-rag-zotero-api-key-status"></html:div>
+
+    <html:div class="setting-row">
+      <html:button id="zotero-rag-run-wizard">Run Setup Wizard…</html:button>
+    </html:div>
+  </html:fieldset>
+
+  <!-- Service API Keys (populated dynamically from the backend's /api/required-keys) -->
+  <html:fieldset class="settings-group" id="zotero-rag-service-keys-group">
+    <html:legend>Service API Keys</html:legend>
+    <html:div id="zotero-rag-service-keys-container">
+      <html:div class="setting-description" id="zotero-rag-service-keys-placeholder">
+        No API keys required for this backend configuration, or not yet connected.
+      </html:div>
+    </html:div>
+  </html:fieldset>
+
+  <!-- Automatic indexing -->
+  <html:fieldset class="settings-group">
+    <html:legend>Automatic indexing</html:legend>
+
+    <html:div class="setting-description">
+      Have the backend automatically index your libraries on a schedule, using the Zotero API
+      key configured above.
+    </html:div>
+
+    <html:div style="display:flex;align-items:center;margin:6px 0 4px 0;">
+      <html:input type="checkbox" id="zotero-rag-autoindex-toggle"/>
+      <html:label for="zotero-rag-autoindex-toggle" style="margin-left:6px;cursor:pointer;">Enable automatic indexing of my libraries</html:label>
+    </html:div>
+
+    <html:div class="setting-description" id="zotero-rag-autoindex-status"></html:div>
+  </html:fieldset>
+```
+
+- [ ] **Step 2: Add a status-line color helper to `preferences.css`**
+
+Append to `plugin/src/preferences.css`:
+
+```css
+.status-ok {
+  color: #006600;
+}
+
+.status-error {
+  color: #cc0000;
+}
+```
+
+- [ ] **Step 3: Verify the XHTML is well-formed**
+
+Run: `python3 -c "import xml.dom.minidom as m; m.parse('plugin/src/preferences.xhtml')" 2>&1 | head -5`
+
+Expected: no output (parses without error). Note: this file is an XML fragment (no single root
+element required by the surrounding `preferences.xhtml` host in Zotero), so a parse error here
+would only be a well-formedness issue (unclosed tags etc.), not a "missing root element" false
+positive — if minidom complains specifically about multiple top-level elements, that's expected
+and not a bug; only unclosed/mismatched tag errors matter.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/src/preferences.xhtml plugin/src/preferences.css
+git commit -m "feat: replace shared API key field with Zotero API key + wizard button in Preferences"
+```
+
+---
+
+## Task 6: Plugin — Preferences logic: wire the Zotero API Key field, wizard button, auto-index checkbox
+
+**Files:**
+- Modify: `plugin/src/preferences.js`
+
+- [ ] **Step 1: Replace the API Key init/listener with the Zotero API Key field + validation**
+
+Replace lines 11-41 of `plugin/src/preferences.js` (from `const backendURL = ...` through the end
+of the `zotero-rag-api-key` change listener):
+
+```js
+	const backendURL = Zotero.Prefs.get('extensions.zotero-rag.backendURL', true) || '';
+	const apiKey = Zotero.Prefs.get('extensions.zotero-rag.apiKey', true) || '';
+	const maxQueries = Zotero.Prefs.get('extensions.zotero-rag.maxQueries', true) || 5;
+
+	// Show stored value; leave blank so the placeholder shows when nothing is saved
+	doc.getElementById('zotero-rag-backend-url').value = backendURL;
+	doc.getElementById('zotero-rag-api-key').value = apiKey;
+	doc.getElementById('zotero-rag-max-queries').value = maxQueries;
+
+	doc.getElementById('zotero-rag-backend-url').addEventListener('change', (e) => {
+		const value = /** @type {HTMLInputElement} */ (e.target).value.trim();
+		if (value === '') {
+			// Clearing the field resets to the default — remove the stored pref
+			Zotero.Prefs.clear('extensions.zotero-rag.backendURL', true);
+			this.backendURL = 'http://localhost:8119';
+		} else {
+			try {
+				new URL(value);
+				Zotero.Prefs.set('extensions.zotero-rag.backendURL', value, true);
+				this.backendURL = value;
+			} catch (_) {
+				Zotero.debug('Zotero RAG: Invalid URL: ' + value);
+			}
+		}
+	});
+
+	doc.getElementById('zotero-rag-api-key').addEventListener('change', (e) => {
+		const key = /** @type {HTMLInputElement} */ (e.target).value;
+		Zotero.Prefs.set('extensions.zotero-rag.apiKey', key, true);
+		this.apiKey = key;
+	});
+```
+
+with:
+
+```js
+	const backendURL = Zotero.Prefs.get('extensions.zotero-rag.backendURL', true) || '';
+	const zoteroApiKey = Zotero.Prefs.get('extensions.zotero-rag.zoteroApiKey', true) || '';
+	const maxQueries = Zotero.Prefs.get('extensions.zotero-rag.maxQueries', true) || 5;
+
+	// Show stored value; leave blank so the placeholder shows when nothing is saved
+	doc.getElementById('zotero-rag-backend-url').value = backendURL;
+	doc.getElementById('zotero-rag-zotero-api-key').value = zoteroApiKey;
+	doc.getElementById('zotero-rag-max-queries').value = maxQueries;
+
+	const zoteroApiKeyStatus = doc.getElementById('zotero-rag-zotero-api-key-status');
+
+	/**
+	 * Validate the currently-configured Zotero API key against the backend
+	 * and show the result in the status line below the field. Also refreshes
+	 * the auto-indexing checkbox, since its availability depends on this key.
+	 * @returns {Promise<void>}
+	 */
+	const refreshZoteroIdentityStatus = async () => {
+		if (!zoteroApiKeyStatus) return;
+		if (this.isLoopbackBackend()) {
+			zoteroApiKeyStatus.textContent = 'Not required for a local server.';
+			zoteroApiKeyStatus.className = 'setting-description';
+			await refreshAutoindexToggle();
+			return;
+		}
+		if (!this.zoteroApiKey) {
+			zoteroApiKeyStatus.textContent = '';
+			zoteroApiKeyStatus.className = 'setting-description';
+			await refreshAutoindexToggle();
+			return;
+		}
+		try {
+			const result = await this.checkZoteroIdentity(this.zoteroApiKey);
+			const count = Array.isArray(result.targets) ? result.targets.length : 0;
+			zoteroApiKeyStatus.textContent = `✓ Authenticated as ${result.username} — ${count} librar${count === 1 ? 'y' : 'ies'} accessible.`;
+			zoteroApiKeyStatus.className = 'setting-description status-ok';
+		} catch (e) {
+			zoteroApiKeyStatus.textContent = `✗ ${e instanceof Error ? e.message : String(e)}`;
+			zoteroApiKeyStatus.className = 'setting-description status-error';
+		}
+		await refreshAutoindexToggle();
+	};
+
+	doc.getElementById('zotero-rag-backend-url').addEventListener('change', (e) => {
+		const value = /** @type {HTMLInputElement} */ (e.target).value.trim();
+		if (value === '') {
+			// Clearing the field resets to the default — remove the stored pref
+			Zotero.Prefs.clear('extensions.zotero-rag.backendURL', true);
+			this.backendURL = 'http://localhost:8119';
+		} else {
+			try {
+				new URL(value);
+				Zotero.Prefs.set('extensions.zotero-rag.backendURL', value, true);
+				this.backendURL = value;
+			} catch (_) {
+				Zotero.debug('Zotero RAG: Invalid URL: ' + value);
+			}
+		}
+		refreshZoteroIdentityStatus();
+	});
+
+	doc.getElementById('zotero-rag-zotero-api-key').addEventListener('change', (e) => {
+		const key = /** @type {HTMLInputElement} */ (e.target).value;
+		Zotero.Prefs.set('extensions.zotero-rag.zoteroApiKey', key, true);
+		this.zoteroApiKey = key;
+		refreshZoteroIdentityStatus();
+	});
+
+	doc.getElementById('zotero-rag-run-wizard').addEventListener('click', () => {
+		this.openSetupWizard(_window);
+	});
+```
+
+- [ ] **Step 2: Replace the autoindex key-entry section with the on/off checkbox**
+
+Find the "Automatic indexing section" block in `plugin/src/preferences.js` — it starts with the
+comment `// Automatic indexing section: submit/remove a read-only Zotero API key` (originally
+lines 256-356, but Task 4's edit shifted this earlier in the file by roughly 60 lines, so search
+for the comment text rather than trusting an exact line number) and runs through the closing of
+the `autoindexRemoveBtn` click listener, right before the function's final closing `};`. Replace
+that entire block with:
+
+```js
+	// Automatic indexing section: a single on/off toggle reusing the same
+	// Zotero API key already configured above (no separate key entry).
+	const autoindexToggle = /** @type {HTMLInputElement|null} */ (doc.getElementById('zotero-rag-autoindex-toggle'));
+	const autoindexStatus = doc.getElementById('zotero-rag-autoindex-status');
+
+	/**
+	 * @param {string} message
+	 * @returns {void}
+	 */
+	const setAutoindexStatus = (message) => {
+		if (autoindexStatus) autoindexStatus.textContent = message;
+	};
+
+	/**
+	 * Reflect current auto-indexing state in the checkbox: checked if a key
+	 * matching the caller's identity is already registered; disabled if no
+	 * Zotero API key is configured yet (nothing to submit).
+	 * @returns {Promise<void>}
+	 */
+	const refreshAutoindexToggle = async () => {
+		if (!autoindexToggle) return;
+		if (!this.zoteroApiKey && !this.isLoopbackBackend()) {
+			autoindexToggle.checked = false;
+			autoindexToggle.disabled = true;
+			setAutoindexStatus('Configure your Zotero API key above first.');
+			return;
+		}
+		try {
+			const response = await fetch(`${this.backendURL}/api/autoindex/keys`, {
+				headers: this.getAuthHeaders(),
+			});
+			if (!response.ok) {
+				autoindexToggle.disabled = true;
+				const err = await response.json().catch(() => ({}));
+				setAutoindexStatus(err.detail || 'Auto-indexing is not available on this server.');
+				return;
+			}
+			/** @type {{keys: Array<unknown>}} */
+			const data = await response.json();
+			autoindexToggle.disabled = false;
+			autoindexToggle.checked = Array.isArray(data.keys) && data.keys.length > 0;
+			setAutoindexStatus(autoindexToggle.checked ? 'Automatic indexing is enabled.' : '');
+		} catch (e) {
+			autoindexToggle.disabled = true;
+			setAutoindexStatus(`Error: ${e}`);
+		}
+	};
+
+	if (autoindexToggle) {
+		autoindexToggle.addEventListener('change', async () => {
+			const enabling = autoindexToggle.checked;
+			const requestURL = `${this.backendURL}/api/autoindex/keys`;
+			setAutoindexStatus(enabling ? 'Enabling auto-indexing...' : 'Disabling auto-indexing...');
+			try {
+				const response = await fetch(requestURL, {
+					method: enabling ? 'POST' : 'DELETE',
+					headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
+					body: JSON.stringify({ api_key: this.zoteroApiKey }),
+				});
+				if (!response.ok) {
+					const err = await response.json().catch(() => ({}));
+					setAutoindexStatus(`Error: ${err.detail || response.status}`);
+					autoindexToggle.checked = !enabling;
+					return;
+				}
+				if (enabling) {
+					/** @type {{targets: string[]}} */
+					const data = await response.json();
+					const count = Array.isArray(data.targets) ? data.targets.length : 0;
+					setAutoindexStatus(count === 1 ? 'Auto-indexing enabled for 1 library.' : `Auto-indexing enabled for ${count} libraries.`);
+				} else {
+					setAutoindexStatus('Auto-indexing disabled.');
+				}
+				this.invalidateAutoIndexedLibraryIds();
+				populateLibraryVisibilityList();
+			} catch (e) {
+				setAutoindexStatus(`Error: ${e}`);
+				autoindexToggle.checked = !enabling;
+			}
+		});
+	}
+```
+
+Note: `refreshAutoindexToggle` and `populateLibraryVisibilityList` are referenced before their
+point of use relative to source order in some cases (`refreshZoteroIdentityStatus` above calls
+`refreshAutoindexToggle`) — this is fine because they're `const` closures all declared in the
+same `initPrefPane` function scope and none of them run until the DOM event listeners fire or the
+explicit calls in Step 3 run, by which point every `const` in the function has been assigned.
+
+- [ ] **Step 3: Trigger the initial status refresh once, after both closures exist**
+
+At the very end of `initPrefPane` (after the `autoindexRemoveBtn`-equivalent block from Step 2,
+i.e. the new last lines of the function), add:
+
+```js
+
+	// Initial population, now that both closures above exist
+	refreshZoteroIdentityStatus();
+```
+
+- [ ] **Step 4: Verify no remaining references to the old pref/id names**
+
+Run: `grep -n "zotero-rag-api-key\b\|extensions.zotero-rag.apiKey\b\|zotero-rag-autoindex-key\|zotero-rag-autoindex-enable\|zotero-rag-autoindex-remove" plugin/src/preferences.js plugin/src/preferences.xhtml`
+
+Expected: no output.
+
+- [ ] **Step 5: Syntax check**
+
+Run: `node --check plugin/src/preferences.js`
+
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugin/src/preferences.js
+git commit -m "feat: wire Zotero API key validation and on/off auto-indexing in Preferences"
+```
+
+---
+
+## Task 7: Plugin — setup wizard dialog
+
+**Files:**
+- Create: `plugin/src/setup-wizard.xhtml`
+- Create: `plugin/src/setup-wizard.js`
+- Modify: `plugin/src/zotero-rag.js` (add `openSetupWizard()`, modeled on `openFixUnavailableDialog()` at line 1574)
+
+- [ ] **Step 1: Create `plugin/src/setup-wizard.xhtml`**
+
+```xml
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <title>Zotero RAG Setup Wizard</title>
+  <meta charset="utf-8"/>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      try {
+        Services.scriptloader.loadSubScript("chrome://zotero/content/include.js", window);
+      } catch (e) {
+        console.error("Failed to load include.js:", e);
+      }
+      try {
+        Services.scriptloader.loadSubScript("chrome://zotero-rag/content/setup-wizard.js", window);
+      } catch (e) {
+        console.error("Failed to load setup-wizard.js:", e);
+      }
+    });
+  </script>
+  <style>
+    html, body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 13px; }
+    .wizard-container { display: flex; flex-direction: column; padding: 16px; box-sizing: border-box; }
+    .wizard-step { display: none; }
+    .wizard-step.active { display: block; }
+    .wizard-step p { color: #444; line-height: 1.5; }
+    .wizard-row { display: flex; align-items: center; margin: 10px 0; gap: 8px; }
+    .wizard-row label { min-width: 140px; font-weight: 500; }
+    .wizard-input { flex: 1; padding: 6px 10px; font-size: 13px; border: 1px solid #ccc; border-radius: 4px; font-family: inherit; }
+    .wizard-status { font-size: 12px; margin: 6px 0; min-height: 15px; }
+    .status-ok { color: #006600; }
+    .status-error { color: #cc0000; }
+    .wizard-buttons { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; border-top: 1px solid #ddd; padding-top: 12px; }
+    .wizard-button { padding: 6px 16px; min-height: 30px; border: 1px solid #ccc; border-radius: 4px; background: #f5f5f5; color: #333; cursor: pointer; font-family: inherit; font-size: 13px; }
+    .wizard-button:hover { background: #e5e5e5; }
+    .wizard-button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .wizard-button.primary { background: #0066cc; color: #fff; border-color: #0066cc; }
+    .wizard-button.primary:hover { background: #0052a3; }
+    .wizard-button.primary:disabled { opacity: 0.5; cursor: not-allowed; background: #0066cc; }
+    #wizard-service-keys-container .setting-row { display: flex; align-items: center; margin: 8px 0; gap: 8px; }
+    #wizard-service-keys-container .setting-row label { min-width: 140px; font-weight: 500; }
+    #wizard-service-keys-container .setting-input { flex: 1; padding: 6px 10px; font-size: 13px; border: 1px solid #ccc; border-radius: 4px; font-family: inherit; }
+    #wizard-service-keys-container .setting-description { font-size: 12px; color: #666; margin: 4px 0 8px; }
+  </style>
+</head>
+
+<body>
+  <div class="wizard-container">
+
+    <!-- Step 1: Server -->
+    <div class="wizard-step active" id="wizard-step-server">
+      <h3>Server</h3>
+      <p>Enter the address of your Zotero RAG backend server.</p>
+      <div class="wizard-row">
+        <label for="wizard-server-url">Server URL:</label>
+        <input id="wizard-server-url" type="text" class="wizard-input" placeholder="http://localhost:8119"/>
+      </div>
+      <div class="wizard-status" id="wizard-server-status"></div>
+    </div>
+
+    <!-- Step 2: Zotero identity -->
+    <div class="wizard-step" id="wizard-step-identity">
+      <h3>Zotero Account</h3>
+      <p id="wizard-identity-intro">
+        This server requires your personal Zotero API key to authenticate you and determine
+        which libraries you can access.
+      </p>
+      <div class="wizard-row">
+        <button type="button" class="wizard-button" id="wizard-create-key-btn">Create key on zotero.org</button>
+      </div>
+      <div class="wizard-row">
+        <label for="wizard-zotero-key">Zotero API Key:</label>
+        <input id="wizard-zotero-key" type="password" class="wizard-input" placeholder="Paste your key here"/>
+        <button type="button" class="wizard-button" id="wizard-validate-btn">Validate</button>
+      </div>
+      <div class="wizard-status" id="wizard-identity-status"></div>
+      <div class="wizard-row" id="wizard-autoindex-row" style="display:none;">
+        <input type="checkbox" id="wizard-autoindex-checkbox"/>
+        <label for="wizard-autoindex-checkbox" style="min-width:auto;cursor:pointer;">Also enable automatic indexing of these libraries</label>
+      </div>
+    </div>
+
+    <!-- Step 3: Service API Keys -->
+    <div class="wizard-step" id="wizard-step-keys">
+      <h3>Service API Keys</h3>
+      <p id="wizard-keys-intro">These API keys are required by the backend's current configuration.</p>
+      <div id="wizard-service-keys-container">
+        <div class="setting-description" id="wizard-service-keys-placeholder">
+          No API keys required for this backend configuration.
+        </div>
+      </div>
+    </div>
+
+    <div class="wizard-buttons">
+      <button type="button" class="wizard-button" id="wizard-cancel-btn">Cancel</button>
+      <button type="button" class="wizard-button" id="wizard-back-btn" disabled="true">Back</button>
+      <button type="button" class="wizard-button primary" id="wizard-next-btn">Next</button>
+    </div>
+
+  </div>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Create `plugin/src/setup-wizard.js`**
+
+```js
+// @ts-check
+// Dialog controller for the Zotero RAG setup wizard (Server -> Zotero identity -> Service API keys).
+
+;(function() {
+	/** @type {Record<string, number>} */
+	const nsFlags = { warn: 0x1, error: 0x0 };
+	const makeLogger = (/** @type {string} */ level) => (/** @type {any[]} */ ...args) => {
+		const msg = "[Zotero RAG / setup-wizard] " + args.join(" ");
+		if (level === "log" || level === "info") {
+			// @ts-ignore
+			Services.console.logStringMessage(msg);
+		} else {
+			// @ts-ignore
+			const e = Cc["@mozilla.org/scripterror;1"].createInstance(Ci.nsIScriptError);
+			// @ts-ignore
+			e.init(msg, "", null, 0, 0, nsFlags[level], "chrome javascript");
+			// @ts-ignore
+			Services.console.logMessage(e);
+		}
+	};
+	// @ts-ignore
+	if (typeof console === "undefined") {
+		// @ts-ignore
+		globalThis.console = { log: makeLogger("log"), info: makeLogger("info"), warn: makeLogger("warn"), error: makeLogger("error") };
+	} else {
+		["log", "info", "warn", "error"].forEach(level => { /** @type {any} */ (console)[level] = makeLogger(level); });
+	}
+})();
+
+var ZoteroSetupWizard = {
+	/** @type {any} */
+	plugin: null,
+
+	/** @type {string[]} */
+	steps: ['wizard-step-server', 'wizard-step-identity', 'wizard-step-keys'],
+
+	/** @type {number} */
+	currentStep: 0,
+
+	/** @type {boolean} */
+	identityValidated: false,
+
+	/**
+	 * Initialise the dialog. Called automatically after DOMContentLoaded loads this script.
+	 * @returns {void}
+	 */
+	init() {
+		// @ts-ignore - window.arguments is available in XUL/Firefox extension context
+		if (!window.arguments || !window.arguments[0]) {
+			console.error("No arguments passed to setup wizard dialog");
+			return;
+		}
+		// @ts-ignore
+		const args = window.arguments[0];
+		this.plugin = args.plugin;
+
+		const backendUrlInput = /** @type {HTMLInputElement} */ (document.getElementById('wizard-server-url'));
+		backendUrlInput.value = this.plugin.backendURL || '';
+
+		document.getElementById('wizard-cancel-btn').addEventListener('click', () => window.close());
+		document.getElementById('wizard-back-btn').addEventListener('click', () => this.goToStep(this.currentStep - 1));
+		document.getElementById('wizard-next-btn').addEventListener('click', () => this.onNext());
+		document.getElementById('wizard-create-key-btn').addEventListener('click', () => {
+			Zotero.launchURL('https://www.zotero.org/settings/keys/new');
+		});
+		document.getElementById('wizard-validate-btn').addEventListener('click', () => this.validateIdentity());
+
+		this.goToStep(0);
+	},
+
+	/**
+	 * @param {number} index
+	 * @returns {void}
+	 */
+	goToStep(index) {
+		if (index < 0 || index >= this.steps.length) return;
+		this.currentStep = index;
+		for (let i = 0; i < this.steps.length; i++) {
+			document.getElementById(this.steps[i]).classList.toggle('active', i === index);
+		}
+		const backBtn = /** @type {HTMLButtonElement} */ (document.getElementById('wizard-back-btn'));
+		const nextBtn = /** @type {HTMLButtonElement} */ (document.getElementById('wizard-next-btn'));
+		backBtn.disabled = index === 0;
+		nextBtn.textContent = index === this.steps.length - 1 ? 'Finish' : 'Next';
+	},
+
+	/**
+	 * Handle the Next/Finish button for the current step.
+	 * @returns {Promise<void>}
+	 */
+	async onNext() {
+		if (this.currentStep === 0) {
+			await this.confirmServer();
+			return;
+		}
+		if (this.currentStep === 1) {
+			if (!this.plugin.isLoopbackBackend() && !this.identityValidated) {
+				const status = document.getElementById('wizard-identity-status');
+				status.textContent = 'Please validate your Zotero API key first.';
+				status.className = 'wizard-status status-error';
+				return;
+			}
+			await this.enterKeysStep();
+			this.goToStep(2);
+			return;
+		}
+		// Step 3 (keys): Finish
+		window.close();
+	},
+
+	/**
+	 * Save + ping the server URL, then decide whether Step 2 (Zotero identity)
+	 * is needed, based on whether the URL points at a loopback address.
+	 * @returns {Promise<void>}
+	 */
+	async confirmServer() {
+		const input = /** @type {HTMLInputElement} */ (document.getElementById('wizard-server-url'));
+		const status = document.getElementById('wizard-server-status');
+		const url = input.value.trim().replace(/\/+$/, '');
+		if (!url) {
+			status.textContent = 'Please enter a server URL.';
+			status.className = 'wizard-status status-error';
+			return;
+		}
+		try {
+			new URL(url);
+		} catch (_) {
+			status.textContent = 'That does not look like a valid URL.';
+			status.className = 'wizard-status status-error';
+			return;
+		}
+		status.textContent = 'Checking server...';
+		status.className = 'wizard-status';
+		Zotero.Prefs.set('extensions.zotero-rag.backendURL', url, true);
+		this.plugin.backendURL = url;
+		try {
+			await this.plugin.checkBackendVersion();
+			status.textContent = '';
+		} catch (e) {
+			// @ts-ignore
+			if (e && (e.status === 401 || e.status === 403)) {
+				// Reachable, just not authenticated yet — expected, continue to Step 2.
+				status.textContent = '';
+			} else {
+				status.textContent = `Could not reach server: ${e instanceof Error ? e.message : String(e)}`;
+				status.className = 'wizard-status status-error';
+				return;
+			}
+		}
+
+		const identityIntro = document.getElementById('wizard-identity-intro');
+		const autoindexRow = document.getElementById('wizard-autoindex-row');
+		if (this.plugin.isLoopbackBackend()) {
+			identityIntro.textContent = 'This server runs on your own machine — no Zotero API key is required.';
+			document.getElementById('wizard-create-key-btn').setAttribute('hidden', 'true');
+			document.getElementById('wizard-zotero-key').setAttribute('hidden', 'true');
+			document.getElementById('wizard-validate-btn').setAttribute('hidden', 'true');
+			autoindexRow.style.display = 'none';
+			this.identityValidated = true;
+			this.goToStep(1);
+			await this.enterKeysStep();
+			this.goToStep(2);
+			return;
+		}
+		this.goToStep(1);
+	},
+
+	/**
+	 * Validate the pasted key against the backend without saving it first.
+	 * @returns {Promise<void>}
+	 */
+	async validateIdentity() {
+		const input = /** @type {HTMLInputElement} */ (document.getElementById('wizard-zotero-key'));
+		const status = document.getElementById('wizard-identity-status');
+		const key = input.value.trim();
+		if (!key) {
+			status.textContent = 'Please paste your Zotero API key.';
+			status.className = 'wizard-status status-error';
+			return;
+		}
+		status.textContent = 'Validating...';
+		status.className = 'wizard-status';
+		try {
+			const result = await this.plugin.checkZoteroIdentity(key);
+			Zotero.Prefs.set('extensions.zotero-rag.zoteroApiKey', key, true);
+			this.plugin.zoteroApiKey = key;
+			this.identityValidated = true;
+			const count = Array.isArray(result.targets) ? result.targets.length : 0;
+			status.textContent = `✓ Authenticated as ${result.username} — ${count} librar${count === 1 ? 'y' : 'ies'} accessible.`;
+			status.className = 'wizard-status status-ok';
+			document.getElementById('wizard-autoindex-row').style.display = 'flex';
+		} catch (e) {
+			this.identityValidated = false;
+			status.textContent = e instanceof Error ? e.message : String(e);
+			status.className = 'wizard-status status-error';
+		}
+	},
+
+	/**
+	 * Populate Step 3 (Service API Keys) and, if requested, submit the
+	 * auto-indexing checkbox state before moving on.
+	 * @returns {Promise<void>}
+	 */
+	async enterKeysStep() {
+		const autoindexCheckbox = /** @type {HTMLInputElement} */ (document.getElementById('wizard-autoindex-checkbox'));
+		if (autoindexCheckbox && autoindexCheckbox.checked && this.plugin.zoteroApiKey) {
+			try {
+				await fetch(`${this.plugin.backendURL}/api/autoindex/keys`, {
+					method: 'POST',
+					headers: this.plugin.getAuthHeaders({ 'Content-Type': 'application/json' }),
+					body: JSON.stringify({ api_key: this.plugin.zoteroApiKey }),
+				});
+			} catch (e) {
+				console.warn('Failed to enable auto-indexing from wizard: ' + e);
+			}
+		}
+
+		await this.plugin.fetchRequiredApiKeys();
+		const container = document.getElementById('wizard-service-keys-container');
+		const placeholder = document.getElementById('wizard-service-keys-placeholder');
+		this.plugin.renderServiceApiKeyFields(document, container, placeholder, this.plugin.requiredApiKeys);
+	},
+};
+
+ZoteroSetupWizard.init();
+```
+
+- [ ] **Step 3: Add `openSetupWizard()` to `zotero-rag.js`**
+
+Add this method to the `ZoteroRAGPlugin` class in `plugin/src/zotero-rag.js`, right after
+`openFixUnavailableDialog()` (around line 1600, after its closing `}`):
+
+```js
+	/**
+	 * Open the setup wizard (Server -> Zotero identity -> Service API keys).
+	 * Focuses the existing dialog instead of opening a second one if already open.
+	 * @param {Window} win - Parent window
+	 * @returns {void}
+	 */
+	openSetupWizard(win) {
+		if (this._setupWizardWindow && !this._setupWizardWindow.closed) {
+			this._setupWizardWindow.focus();
+			return;
+		}
+		// @ts-ignore - openDialog is available in XUL/Firefox extension context
+		this._setupWizardWindow = win.openDialog(
+			'chrome://zotero-rag/content/setup-wizard.xhtml',
+			'zotero-rag-setup-wizard',
+			'chrome,centerscreen,resizable=yes,width=520,height=480',
+			{ plugin: this }
+		);
+	}
+```
+
+Also add the corresponding property to the constructor, next to `_fixUnavailableWindow`'s
+declaration pattern — add near `this._dialogWindow` in the constructor (`plugin/src/zotero-rag.js`,
+inside the constructor block):
+
+```js
+		/** @type {Window|null} */
+		this._setupWizardWindow = null;
+```
+
+- [ ] **Step 4: Syntax check both new files and the modified one**
+
+Run: `node --check plugin/src/setup-wizard.js && node --check plugin/src/zotero-rag.js && python3 -c "import xml.dom.minidom as m; m.parse('plugin/src/setup-wizard.xhtml')"`
+
+Expected: no output from any of the three commands.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/src/setup-wizard.xhtml plugin/src/setup-wizard.js plugin/src/zotero-rag.js
+git commit -m "feat: add setup wizard dialog (server, Zotero identity, service API keys)"
+```
+
+---
+
+## Task 8: Plugin — auto-launch the wizard on a 401/403 startup failure
+
+**Files:**
+- Modify: `plugin/src/zotero-rag.js:411-433` (`main()`)
+
+- [ ] **Step 1: Update `main()` to auto-launch the wizard once per session**
+
+Replace `main()` (`plugin/src/zotero-rag.js:411-433`):
+
+```js
+	/**
+	 * Main plugin entry point.
+	 * @returns {Promise<void>}
+	 */
+	async main() {
+		this.log(`Plugin initialized with backend URL: ${this.backendURL}`);
+
+		// Check backend version compatibility
+		try {
+			await this.checkBackendVersion();
+		} catch (e) {
+			const errorMessage = e instanceof Error ? e.message : String(e);
+			this.log(`Backend not available: ${errorMessage}`);
+			return;
+		}
+
+		// Log backend service configuration and DB statistics
+		try {
+			await this.logServerInfo();
+		} catch (e) {
+			this.log(`Could not fetch server info: ${e instanceof Error ? e.message : String(e)}`);
+		}
+	}
+```
+
+with:
+
+```js
+	/**
+	 * Main plugin entry point.
+	 * @returns {Promise<void>}
+	 */
+	async main() {
+		this.log(`Plugin initialized with backend URL: ${this.backendURL}`);
+
+		// Check backend version compatibility
+		try {
+			await this.checkBackendVersion();
+		} catch (e) {
+			const errorMessage = e instanceof Error ? e.message : String(e);
+			this.log(`Backend not available: ${errorMessage}`);
+			// @ts-ignore
+			const status = e && e.status;
+			if ((status === 401 || status === 403) && !this.isLoopbackBackend() && !this._wizardAutoLaunchedThisSession) {
+				this._wizardAutoLaunchedThisSession = true;
+				const win = Zotero.getMainWindow();
+				if (win) this.openSetupWizard(win);
+			}
+			return;
+		}
+
+		// Log backend service configuration and DB statistics
+		try {
+			await this.logServerInfo();
+		} catch (e) {
+			this.log(`Could not fetch server info: ${e instanceof Error ? e.message : String(e)}`);
+		}
+	}
+```
+
+- [ ] **Step 2: Syntax check**
+
+Run: `node --check plugin/src/zotero-rag.js`
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugin/src/zotero-rag.js
+git commit -m "feat: auto-launch setup wizard on 401/403 startup failure"
+```
+
+---
+
+## Task 9: Documentation updates
+
+**Files:**
+- Modify: `CLAUDE.md` (cron indexer section)
+- Modify: `docs/history/implementation/master.md` (append summary)
+
+- [ ] **Step 1: Update the cron-indexer section of `CLAUDE.md`**
+
+In `CLAUDE.md`, find the paragraph under "### Debugging the cron indexer" that begins
+"**Key flow — auto-index keys (not `--slugs-file` / `ZOTERO_API_KEY`):**" and add one sentence
+directly after it, before the `uv run python bin/autoindex_add_key.py` example:
+
+```markdown
+As of the zotero-key-auth migration, the same personal Zotero API key a user enters in the
+plugin's setup wizard (or Preferences) also authenticates their normal plugin use — auto-indexing
+is just an on/off toggle reusing that key, not a separate credential.
+```
+
+- [ ] **Step 2: Append a phase summary to `docs/history/implementation/master.md`**
+
+Add this section at the end of `docs/history/implementation/master.md`:
+
+```markdown
+
+## Zotero-Key Authentication Migration (2026-07)
+
+Replaced the single shared `X-API-Key` secret with per-user Zotero.org authentication, closing an
+IDOR where any user with the shared key could read/delete any other user's library.
+
+- **Backend (Parts 1–2):** identity-derived authorization — every request's Zotero API key
+  resolves to `(user_id, username, targets)` via `api.zotero.org`, cached with a TTL; every
+  library-scoped endpoint checks `library_id ∈ targets`. A Part 2 access gate (group membership
+  and/or an explicit user-id allowlist) controls who may use the instance at all. See
+  `docs/history/plan-zotero-key-auth.md`.
+- **Plugin + cutover (Part 3 + Part 5):** the plugin now sends `X-Zotero-API-Key` instead of the
+  shared secret; a 3-step setup wizard (Server → Zotero identity → Service API keys) obtains and
+  validates the key via the new `GET /api/auth/whoami`; auto-indexing collapsed to a single on/off
+  toggle reusing that same key. The backend's transitional shared-secret fallback was removed in
+  the same change (no staged migration window — single-operator deployment). See
+  `docs/superpowers/specs/2026-07-06-zotero-key-auth-plugin-wizard-design.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md docs/history/implementation/master.md
+git commit -m "docs: document the zotero-key-auth migration's plugin/cutover phase"
+```
+
+---
+
+## Task 10: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full backend test suite**
+
+Run: `uv run pytest backend/tests/ -v`
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Grep for any remaining dead references across both backend and plugin**
+
+Run: `grep -rn "settings\.api_key\b\|X-API-Key\|extensions\.zotero-rag\.apiKey\b\|addApiKeyParam" backend plugin/src`
+
+Expected: no output (all removed/renamed). Note this intentionally does not match
+`extensions.zotero-rag.serviceApiKey.*` or `request.api_key` (the `KeyRequest.api_key` field in
+`backend/api/autoindex.py`, a different concept — the submitted auto-index key's field name).
+
+- [ ] **Step 3: Invoke the `verify` skill for manual end-to-end verification**
+
+Use the project's `verify` skill to drive the plugin against a local dev backend
+(`npm start`, loopback — `http://localhost:8119`) and confirm:
+- Preferences pane loads with the new "Zotero API Key" field and shows "Not required for a local
+  server." in the status line.
+- The "Automatic indexing" checkbox is enabled (loopback allows it without a key) and toggling it
+  calls the backend without error.
+- Clicking "Run Setup Wizard…" opens the dialog, Step 1 pings the local server successfully, and
+  because it's loopback, Steps 2 is skipped straight to Step 3 (Service API Keys).
+- Manually testing the non-loopback 401/403 → auto-launch path requires a remote/gated deployment
+  and is not feasible in local dev — note this as a follow-up manual check to run once a
+  non-loopback test server is available, rather than blocking on it here.
+
+- [ ] **Step 4: Report results to the user**
+
+Summarize what was verified automatically (backend suite) versus manually (plugin, loopback path
+only) and flag the non-loopback wizard auto-launch path as unverified pending a real remote
+deployment.

--- a/docs/superpowers/specs/2026-07-06-zotero-key-auth-plugin-wizard-design.md
+++ b/docs/superpowers/specs/2026-07-06-zotero-key-auth-plugin-wizard-design.md
@@ -1,0 +1,189 @@
+# Design: Plugin setup wizard + Zotero-key auth cutover (Part 3 + Part 5 cutover)
+
+## Problem this fixes
+
+`docs/history/plan-zotero-key-auth.md` (Parts 1–2) already replaced the backend's shared-secret
+auth with per-user Zotero-key identity + an access gate — but only on the backend. The plugin
+still sends the old shared `X-API-Key` (`extensions.zotero-rag.apiKey`), and the backend still
+accepts it as a transitional fallback (`resolve_zotero_identity` in `backend/dependencies.py`).
+There is also no plugin UI to obtain, validate, or store a personal Zotero API key, and no
+backend endpoint for such a UI to call.
+
+The user owns and controls every deployed server, so this plan completes the migration in one
+step: switch the plugin to the new auth model and remove the transitional backend fallback,
+rather than running both indefinitely.
+
+## Decisions
+
+1. **Backend cutover now.** Remove `settings.api_key` and the legacy `X-API-Key`/`?api_key=`
+   branch in `resolve_zotero_identity` entirely. Loopback no-auth mode (Part 4) is untouched.
+2. **New endpoint, not the design doc's original proposal.** Add `GET /api/auth/whoami` that
+   reads back the identity the auth middleware already resolved (via `get_zotero_identity`),
+   rather than the design doc's `POST /api/auth/validate` with its own validation path. This
+   avoids a second, parallel validation code path — the middleware already does 401/403/503
+   handling for any authenticated route.
+3. **Preferences pane keeps direct key entry** (masked field with inline validation) in addition
+   to the wizard, so a quick key rotation doesn't require stepping through the wizard.
+4. **Auto-indexing becomes a single on/off checkbox** reusing the already-configured Zotero API
+   key — no second key entry for auto-indexing.
+5. **Wizard auto-launches** on a 401/403 startup failure against a non-loopback backend (once per
+   session), in addition to a manual "Run Setup Wizard" button in Preferences.
+6. **No new "join group" deep-link feature.** On a 403 gate rejection, the wizard shows the
+   backend's plain error text. Building operator-configurable contact/join-URL info is a
+   speculative feature not requested and is left out.
+
+## Backend changes
+
+### Remove the legacy shared-secret path
+
+- `backend/config/settings.py`: remove the `api_key` field.
+- `backend/dependencies.py::resolve_zotero_identity`: remove the
+  `legacy_key = request.headers.get("X-API-Key") or request.query_params.get("api_key")` branch
+  and its `settings.api_key` comparison. A missing `X-Zotero-API-Key` header on a non-loopback
+  request is unconditionally a 401.
+- `backend/main.py`: update the `api_key_middleware` docstring (no more "legacy shared secret"
+  mention) and remove any other reference to `settings.api_key`.
+- Remove/update tests that exercised the legacy shared-key path (see Testing section).
+- `.env.dist`: remove the `API_KEY` documentation for remote mode (loopback mode needs no key at
+  all, so there is nothing to replace it with there).
+
+### `GET /api/auth/whoami`
+
+New router (or added to an existing small router, e.g. `backend/api/autoindex.py` is auto-index
+specific — prefer a new `backend/api/auth.py`), registered under `/api` prefix, subject to the
+normal auth middleware (i.e. NOT in `_AUTH_EXEMPT_PATHS`):
+
+```python
+@router.get("/auth/whoami")
+def whoami(identity: Optional[ZoteroIdentity] = Depends(get_zotero_identity)) -> dict:
+    if identity is None:
+        return {"authorized": True, "loopback": True}
+    return {
+        "authorized": True,
+        "loopback": False,
+        "user_id": identity.user_id,
+        "username": identity.username,
+        "targets": identity.targets,
+    }
+```
+
+Failure cases (missing key, invalid/revoked key, gate rejection, zotero.org unreachable) never
+reach the handler — the middleware already raises 401/403/503 with a `detail` message. The wizard
+and Preferences pane read the HTTP status + `detail` directly.
+
+## Plugin changes
+
+### Preferences pane (`preferences.xhtml` / `preferences.js`)
+
+**Backend Server section:**
+- Remove the "API Key" row (`zotero-rag-api-key-row`, `zotero-rag-api-key-desc`) entirely.
+- Add a "Zotero API Key" row (new id `zotero-rag-zotero-api-key`) bound to a new pref
+  `extensions.zotero-rag.zoteroApiKey`, saved on `change` like other fields.
+- Add a status line below it, populated by a background call to `GET /api/auth/whoami` (using the
+  candidate key) after save: `"✓ Authenticated as <username> — N libraries accessible"` on
+  success, the error `detail` text on failure, or `"Not required for a local server."` when the
+  configured backend host is `localhost`/`127.0.0.1`.
+- Add a button `zotero-rag-run-wizard` ("Run Setup Wizard…") in this section that calls
+  `openSetupWizard(win)`.
+
+**Automatic indexing section:**
+- Replace the "Read-only API key" input, "Enable auto-indexing" and "Remove" buttons with a
+  single checkbox `zotero-rag-autoindex-toggle` ("Enable automatic indexing of my libraries").
+- On pane load, call `GET /api/autoindex/keys` to determine current state (a key is registered
+  for this user) and set the checkbox accordingly.
+- On check: `POST /api/autoindex/keys` with `{api_key: <zoteroApiKey pref value>}`. On uncheck:
+  `DELETE /api/autoindex/keys` with the same body. Status text below reports the result (library
+  count / error), same as today.
+- The checkbox is disabled, with a hint text ("Configure your Zotero API key above first"), when
+  `zoteroApiKey` is empty.
+
+**Service API Keys section:** unchanged.
+
+### `zotero-rag.js`
+
+- Rename the `apiKey` property/pref usage to `zoteroApiKey` throughout
+  (`this.apiKey` at init, `getAuthHeaders()`, `fetchRequiredApiKeys()`'s header, etc.). Pref key
+  becomes `extensions.zotero-rag.zoteroApiKey`.
+- `getAuthHeaders()`: send `X-Zotero-API-Key` instead of `X-API-Key`.
+- Delete `addApiKeyParam()` (dead code today — 0 callers, no SSE/EventSource consumer exists in
+  the plugin) rather than updating it for the new key name.
+- `checkBackendVersion()`: currently throws a generic `Error` with the status folded into the
+  message string. Change it to preserve the HTTP status code (e.g. attach it as an `.status`
+  property on the thrown Error, or return a `{status, detail}` shape) so `main()` can distinguish
+  "auth/gate failure" (401/403) from "server unreachable" (network error) or other statuses.
+- `main()`: after a 401/403 from `checkBackendVersion()`, if the configured backend host is not
+  `localhost`/`127.0.0.1`, and the wizard hasn't already auto-opened this session (a simple
+  in-memory flag, not a pref — so it offers again next Zotero restart if still unresolved), call
+  `openSetupWizard(win)` on the active main window.
+
+### New setup wizard (`setup-wizard.xhtml`, `setup-wizard.js`)
+
+Modeled on the existing `fix-unavailable.xhtml`/`.js` pattern: an XHTML dialog loaded via
+`Services.scriptloader.loadSubScript`, opened with
+`win.openDialog('chrome://zotero-rag/content/setup-wizard.xhtml', 'zotero-rag-setup-wizard', 'chrome,centerscreen,resizable=yes,width=520,height=480', { plugin: this })`.
+A single dialog with a step indicator (not separate windows), three steps:
+
+**Step 1 — Server**
+- Server URL input, pre-filled from `extensions.zotero-rag.backendURL`.
+- "Next": saves the URL, calls `GET /api/version` to confirm reachability, and checks client-side
+  whether the URL's hostname is `localhost`/`127.0.0.1` to decide whether Step 2 is shown or
+  skipped (with a note: "Not required for a local server").
+
+**Step 2 — Zotero identity** (skipped when loopback)
+- Explanatory text on why a Zotero key is required.
+- "Create key on zotero.org" button → `Zotero.launchURL('https://www.zotero.org/settings/keys/new')`.
+- Password input for the key + "Validate" button → calls `GET /api/auth/whoami` with the
+  candidate key in `X-Zotero-API-Key` (not yet saved to prefs).
+- On success: saves the key to `extensions.zotero-rag.zoteroApiKey`, shows the authenticated
+  username + accessible library count, and reveals a checkbox "Also enable automatic indexing of
+  these libraries" (checked state submitted via `POST /api/autoindex/keys` on Finish).
+- On failure: shows the response's `detail` text inline; "Next" stays disabled until validation
+  succeeds (or the user goes back to fix the Server URL).
+
+**Step 3 — Service API Keys**
+- Renders the same dynamic list as Preferences' "Service API Keys" section
+  (`GET /api/required-keys`), each saved to `extensions.zotero-rag.serviceApiKey.<key_name>` on
+  change. Reuse the rendering logic from `preferences.js` (extract into a small shared helper
+  rather than duplicating the DOM-building code — see Testing/implementation note below).
+
+**Finish**
+- Values are already saved incrementally per step; "Finish" just closes the dialog. If the
+  Preferences pane is open in another window, it isn't live-refreshed automatically — closing
+  and reopening Preferences shows the new values (no cross-window sync is being added; out of
+  scope).
+
+## Migration / cleanup
+
+- The old `extensions.zotero-rag.apiKey` pref is simply no longer read or written. No explicit
+  migration/clearing — an orphaned value in `about:config` is harmless.
+- `docs/history/plan-zotero-key-auth.md` Part 5 migration steps 3–4 (announce cutover, monitor
+  legacy usage, remove legacy fallback) collapse into this plan's backend cutover, since there is
+  no announcement/monitoring window — same person controls plugin and server rollout.
+- Doc updates (per the design doc's Part 6 table, scoped to what's now built): `CLAUDE.md`
+  cron-indexer section already documents the auto-index key flow — add a note that the same key
+  now also authenticates normal plugin use. `.env.dist` update as above. No new
+  `docs/zotero-auth.md` — the existing design doc plus this spec cover it; a dedicated reference
+  doc is not needed for a single-operator deployment.
+
+## Testing
+
+- **Backend:** unit tests for `GET /api/auth/whoami` (success with identity, success with
+  loopback, 401/403/503 pass-through from the dependency). Remove/update tests in
+  `backend/tests/` that relied on `settings.api_key` / legacy shared-key acceptance. Add a test
+  confirming a request with only the old `X-API-Key` header (no `X-Zotero-API-Key`) now gets 401
+  on a non-loopback host.
+- **Plugin:** `plugin/test/` — tests for `getAuthHeaders()` sending `X-Zotero-API-Key`; a test for
+  the auto-indexing checkbox reading initial state from `GET /api/autoindex/keys` and toggling
+  correctly; wizard step-transition tests mocking `GET /api/version` and `GET /api/auth/whoami`
+  responses (success, 401, 403, loopback-skip).
+- **Manual verification (per `verify` skill):** run the plugin against a local dev backend
+  (loopback — wizard should skip Step 2) and, if feasible, against a non-loopback test
+  configuration to exercise the full 401 → auto-launch → validate → success path.
+
+## Out of scope
+
+- Operator-configurable "join group" URL / contact message on gate rejection.
+- Cross-window live refresh of Preferences when the wizard changes settings from a dialog.
+- Prefill query params on the zotero.org "create key" URL (not verified whether the site supports
+  them; ship a plain link, revisit later if desired).
+- Any change to the `/public/*` unauthenticated query UI (unrelated to plugin/user auth).

--- a/plugin/src/preferences.css
+++ b/plugin/src/preferences.css
@@ -109,3 +109,11 @@ body {
   position: relative;
   top: 3px;
 }
+
+.status-ok {
+  color: #006600;
+}
+
+.status-error {
+  color: #cc0000;
+}

--- a/plugin/src/preferences.js
+++ b/plugin/src/preferences.js
@@ -257,7 +257,10 @@ ZoteroRAGPlugin.prototype.initPrefPane = function(_window) {
 	 */
 	const refreshAutoindexToggle = async () => {
 		if (!autoindexToggle) return;
-		if (!this.zoteroApiKey && !this.isLoopbackBackend()) {
+		// Auto-indexing always needs a real Zotero key (it drives a cron job that
+		// hits api.zotero.org), even when the backend connection itself is loopback
+		// and needs no key for plugin auth — so this check is unconditional.
+		if (!this.zoteroApiKey) {
 			autoindexToggle.checked = false;
 			autoindexToggle.disabled = true;
 			setAutoindexStatus('Configure your Zotero API key above first.');

--- a/plugin/src/preferences.js
+++ b/plugin/src/preferences.js
@@ -61,76 +61,19 @@ ZoteroRAGPlugin.prototype.initPrefPane = function(_window) {
 		}
 	});
 
-	/**
-	 * Render service API key input fields from the given list.
-	 * @param {Array<{key_name: string, header_name: string, description: string, docs_url?: string|null, required_for: string[]}>} requiredKeys
-	 */
-	const renderApiKeyFields = (requiredKeys) => {
-		const container = doc.getElementById('zotero-rag-service-keys-container');
-		const placeholder = doc.getElementById('zotero-rag-service-keys-placeholder');
-		if (!container) return;
-
-		// Remove previously rendered dynamic rows
-		container.querySelectorAll('.service-key-row, .service-key-desc').forEach(el => el.remove());
-
-		if (!requiredKeys || requiredKeys.length === 0) {
-			if (placeholder) placeholder.style.display = '';
-			return;
-		}
-		if (placeholder) placeholder.style.display = 'none';
-
-		for (const keyInfo of requiredKeys) {
-			const prefKey = `extensions.zotero-rag.serviceApiKey.${keyInfo.key_name}`;
-			const storedValue = Zotero.Prefs.get(prefKey, true) || '';
-
-			const row = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-			row.className = 'setting-row service-key-row';
-
-			const label = doc.createElementNS('http://www.w3.org/1999/xhtml', 'label');
-			label.textContent = `${keyInfo.key_name}:`;
-			label.setAttribute('for', `zotero-rag-key-${keyInfo.key_name}`);
-
-			const input = /** @type {HTMLInputElement} */ (doc.createElementNS('http://www.w3.org/1999/xhtml', 'input'));
-			input.type = 'password';
-			input.id = `zotero-rag-key-${keyInfo.key_name}`;
-			input.className = 'setting-input';
-			input.value = storedValue;
-			input.placeholder = 'Enter API key';
-			input.addEventListener('change', (e) => {
-				Zotero.Prefs.set(prefKey, /** @type {HTMLInputElement} */ (e.target).value, true);
-			});
-
-			row.appendChild(label);
-			row.appendChild(input);
-			container.appendChild(row);
-
-			if (keyInfo.description) {
-				const desc = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-				desc.className = 'setting-description service-key-desc';
-				desc.textContent = `${keyInfo.description} (used for: ${keyInfo.required_for.join(', ')})`;
-				// Link to the provider portal where the key can be created/managed.
-				// Clicks are routed to the system browser by the pane-wide handler above.
-				if (keyInfo.docs_url && /^https?:\/\//i.test(keyInfo.docs_url)) {
-					desc.appendChild(doc.createTextNode(' '));
-					const link = doc.createElementNS('http://www.w3.org/1999/xhtml', 'a');
-					link.setAttribute('href', keyInfo.docs_url);
-					link.setAttribute('target', '_blank');
-					link.textContent = 'Get key';
-					desc.appendChild(link);
-				}
-				container.appendChild(desc);
-			}
-		}
-	};
+	const serviceKeysContainer = doc.getElementById('zotero-rag-service-keys-container');
+	const serviceKeysPlaceholder = doc.getElementById('zotero-rag-service-keys-placeholder');
 
 	// Render from cache immediately so fields appear without needing a server round-trip
 	try {
 		const cached = Zotero.Prefs.get('extensions.zotero-rag.requiredApiKeys', true) || '[]';
-		renderApiKeyFields(JSON.parse(cached));
+		this.renderServiceApiKeyFields(doc, serviceKeysContainer, serviceKeysPlaceholder, JSON.parse(cached));
 	} catch (_) {}
 
 	// Refresh from server in background and re-render if the list has changed
-	this.fetchRequiredApiKeys().then(() => renderApiKeyFields(this.requiredApiKeys));
+	this.fetchRequiredApiKeys().then(() =>
+		this.renderServiceApiKeyFields(doc, serviceKeysContainer, serviceKeysPlaceholder, this.requiredApiKeys)
+	);
 
 	// Library visibility section
 	const populateLibraryVisibilityList = () => {

--- a/plugin/src/preferences.js
+++ b/plugin/src/preferences.js
@@ -9,13 +9,47 @@ ZoteroRAGPlugin.prototype.initPrefPane = function(_window) {
 	const doc = _window.document;
 
 	const backendURL = Zotero.Prefs.get('extensions.zotero-rag.backendURL', true) || '';
-	const apiKey = Zotero.Prefs.get('extensions.zotero-rag.apiKey', true) || '';
+	const zoteroApiKey = Zotero.Prefs.get('extensions.zotero-rag.zoteroApiKey', true) || '';
 	const maxQueries = Zotero.Prefs.get('extensions.zotero-rag.maxQueries', true) || 5;
 
 	// Show stored value; leave blank so the placeholder shows when nothing is saved
 	doc.getElementById('zotero-rag-backend-url').value = backendURL;
-	doc.getElementById('zotero-rag-api-key').value = apiKey;
+	doc.getElementById('zotero-rag-zotero-api-key').value = zoteroApiKey;
 	doc.getElementById('zotero-rag-max-queries').value = maxQueries;
+
+	const zoteroApiKeyStatus = doc.getElementById('zotero-rag-zotero-api-key-status');
+
+	/**
+	 * Validate the currently-configured Zotero API key against the backend
+	 * and show the result in the status line below the field. Also refreshes
+	 * the auto-indexing checkbox, since its availability depends on this key.
+	 * @returns {Promise<void>}
+	 */
+	const refreshZoteroIdentityStatus = async () => {
+		if (!zoteroApiKeyStatus) return;
+		if (this.isLoopbackBackend()) {
+			zoteroApiKeyStatus.textContent = 'Not required for a local server.';
+			zoteroApiKeyStatus.className = 'setting-description';
+			await refreshAutoindexToggle();
+			return;
+		}
+		if (!this.zoteroApiKey) {
+			zoteroApiKeyStatus.textContent = '';
+			zoteroApiKeyStatus.className = 'setting-description';
+			await refreshAutoindexToggle();
+			return;
+		}
+		try {
+			const result = await this.checkZoteroIdentity(this.zoteroApiKey);
+			const count = Array.isArray(result.targets) ? result.targets.length : 0;
+			zoteroApiKeyStatus.textContent = `✓ Authenticated as ${result.username} — ${count} librar${count === 1 ? 'y' : 'ies'} accessible.`;
+			zoteroApiKeyStatus.className = 'setting-description status-ok';
+		} catch (e) {
+			zoteroApiKeyStatus.textContent = `✗ ${e instanceof Error ? e.message : String(e)}`;
+			zoteroApiKeyStatus.className = 'setting-description status-error';
+		}
+		await refreshAutoindexToggle();
+	};
 
 	doc.getElementById('zotero-rag-backend-url').addEventListener('change', (e) => {
 		const value = /** @type {HTMLInputElement} */ (e.target).value.trim();
@@ -32,12 +66,18 @@ ZoteroRAGPlugin.prototype.initPrefPane = function(_window) {
 				Zotero.debug('Zotero RAG: Invalid URL: ' + value);
 			}
 		}
+		refreshZoteroIdentityStatus();
 	});
 
-	doc.getElementById('zotero-rag-api-key').addEventListener('change', (e) => {
+	doc.getElementById('zotero-rag-zotero-api-key').addEventListener('change', (e) => {
 		const key = /** @type {HTMLInputElement} */ (e.target).value;
-		Zotero.Prefs.set('extensions.zotero-rag.apiKey', key, true);
-		this.apiKey = key;
+		Zotero.Prefs.set('extensions.zotero-rag.zoteroApiKey', key, true);
+		this.zoteroApiKey = key;
+		refreshZoteroIdentityStatus();
+	});
+
+	doc.getElementById('zotero-rag-run-wizard').addEventListener('click', () => {
+		this.openSetupWizard(_window);
 	});
 
 	doc.getElementById('zotero-rag-max-queries').addEventListener('change', (e) => {
@@ -196,15 +236,12 @@ ZoteroRAGPlugin.prototype.initPrefPane = function(_window) {
 		}
 	});
 
-	// Automatic indexing section: submit/remove a read-only Zotero API key
-	// so the backend can auto-index the user's library on a schedule.
-	const autoindexKeyInput = /** @type {HTMLInputElement|null} */ (doc.getElementById('zotero-rag-autoindex-key'));
+	// Automatic indexing section: a single on/off toggle reusing the same
+	// Zotero API key already configured above (no separate key entry).
+	const autoindexToggle = /** @type {HTMLInputElement|null} */ (doc.getElementById('zotero-rag-autoindex-toggle'));
 	const autoindexStatus = doc.getElementById('zotero-rag-autoindex-status');
-	const autoindexEnableBtn = doc.getElementById('zotero-rag-autoindex-enable');
-	const autoindexRemoveBtn = doc.getElementById('zotero-rag-autoindex-remove');
 
 	/**
-	 * Show a status message in the auto-indexing section.
 	 * @param {string} message
 	 * @returns {void}
 	 */
@@ -212,89 +249,75 @@ ZoteroRAGPlugin.prototype.initPrefPane = function(_window) {
 		if (autoindexStatus) autoindexStatus.textContent = message;
 	};
 
-	if (autoindexEnableBtn) {
-		autoindexEnableBtn.addEventListener('click', async () => {
-			const apiKey = autoindexKeyInput ? autoindexKeyInput.value.trim() : '';
-			if (!apiKey) {
-				setAutoindexStatus('Please enter a read-only Zotero API key.');
+	/**
+	 * Reflect current auto-indexing state in the checkbox: checked if a key
+	 * matching the caller's identity is already registered; disabled if no
+	 * Zotero API key is configured yet (nothing to submit).
+	 * @returns {Promise<void>}
+	 */
+	const refreshAutoindexToggle = async () => {
+		if (!autoindexToggle) return;
+		if (!this.zoteroApiKey && !this.isLoopbackBackend()) {
+			autoindexToggle.checked = false;
+			autoindexToggle.disabled = true;
+			setAutoindexStatus('Configure your Zotero API key above first.');
+			return;
+		}
+		try {
+			const response = await fetch(`${this.backendURL}/api/autoindex/keys`, {
+				headers: this.getAuthHeaders(),
+			});
+			if (!response.ok) {
+				autoindexToggle.disabled = true;
+				const err = await response.json().catch(() => ({}));
+				setAutoindexStatus(err.detail || 'Auto-indexing is not available on this server.');
 				return;
 			}
+			/** @type {{keys: Array<unknown>}} */
+			const data = await response.json();
+			autoindexToggle.disabled = false;
+			autoindexToggle.checked = Array.isArray(data.keys) && data.keys.length > 0;
+			setAutoindexStatus(autoindexToggle.checked ? 'Automatic indexing is enabled.' : '');
+		} catch (e) {
+			autoindexToggle.disabled = true;
+			setAutoindexStatus(`Error: ${e}`);
+		}
+	};
+
+	if (autoindexToggle) {
+		autoindexToggle.addEventListener('change', async () => {
+			const enabling = autoindexToggle.checked;
 			const requestURL = `${this.backendURL}/api/autoindex/keys`;
-			setAutoindexStatus('Enabling auto-indexing...');
+			setAutoindexStatus(enabling ? 'Enabling auto-indexing...' : 'Disabling auto-indexing...');
 			try {
 				const response = await fetch(requestURL, {
-					method: 'POST',
+					method: enabling ? 'POST' : 'DELETE',
 					headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
-					body: JSON.stringify({ api_key: apiKey })
+					body: JSON.stringify({ api_key: this.zoteroApiKey }),
 				});
 				if (!response.ok) {
-					// A 301 redirect from HTTP to HTTPS silently converts POST→GET, causing 405.
-					if (requestURL.startsWith('http://') && response.url && response.url.startsWith('https://')) {
-						setAutoindexStatus(
-							'Backend URL is configured as HTTP but the server requires HTTPS. ' +
-							'Please update the Backend URL to start with "https://".'
-						);
-						return;
-					}
 					const err = await response.json().catch(() => ({}));
 					setAutoindexStatus(`Error: ${err.detail || response.status}`);
+					autoindexToggle.checked = !enabling;
 					return;
 				}
-				/** @type {{user_id: string, username: string, targets: string[]}} */
-				const data = await response.json();
-				const count = Array.isArray(data.targets) ? data.targets.length : 0;
-				setAutoindexStatus(
-					count === 1
-						? 'Auto-indexing enabled for 1 library.'
-						: `Auto-indexing enabled for ${count} libraries.`
-				);
-				if (autoindexKeyInput) autoindexKeyInput.value = '';
-				// Refresh the visibility list so the newly auto-indexed libraries get the clock icon
+				if (enabling) {
+					/** @type {{targets: string[]}} */
+					const data = await response.json();
+					const count = Array.isArray(data.targets) ? data.targets.length : 0;
+					setAutoindexStatus(count === 1 ? 'Auto-indexing enabled for 1 library.' : `Auto-indexing enabled for ${count} libraries.`);
+				} else {
+					setAutoindexStatus('Auto-indexing disabled.');
+				}
 				this.invalidateAutoIndexedLibraryIds();
 				populateLibraryVisibilityList();
 			} catch (e) {
 				setAutoindexStatus(`Error: ${e}`);
+				autoindexToggle.checked = !enabling;
 			}
 		});
 	}
 
-	if (autoindexRemoveBtn) {
-		autoindexRemoveBtn.addEventListener('click', async () => {
-			const apiKey = autoindexKeyInput ? autoindexKeyInput.value.trim() : '';
-			if (!apiKey) {
-				setAutoindexStatus('Please enter the read-only Zotero API key to remove.');
-				return;
-			}
-			const requestURL = `${this.backendURL}/api/autoindex/keys`;
-			setAutoindexStatus('Removing auto-indexing key...');
-			try {
-				const response = await fetch(requestURL, {
-					method: 'DELETE',
-					headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
-					body: JSON.stringify({ api_key: apiKey })
-				});
-				if (!response.ok) {
-					if (requestURL.startsWith('http://') && response.url && response.url.startsWith('https://')) {
-						setAutoindexStatus(
-							'Backend URL is configured as HTTP but the server requires HTTPS. ' +
-							'Please update the Backend URL to start with "https://".'
-						);
-						return;
-					}
-					const err = await response.json().catch(() => ({}));
-					setAutoindexStatus(`Error: ${err.detail || response.status}`);
-					return;
-				}
-				/** @type {{removed: boolean}} */
-				const data = await response.json();
-				setAutoindexStatus(data.removed ? 'Auto-indexing key removed.' : 'No matching key found.');
-				if (autoindexKeyInput) autoindexKeyInput.value = '';
-				// Refresh the visibility list so removed libraries lose the clock icon
-				this.invalidateAutoIndexedLibraryIds();
-				populateLibraryVisibilityList();
-			} catch (e) {
-				setAutoindexStatus(`Error: ${e}`);
-			}
-		});
-	}
+	// Initial population, now that both closures above exist
+	refreshZoteroIdentityStatus();
 };

--- a/plugin/src/preferences.xhtml
+++ b/plugin/src/preferences.xhtml
@@ -22,20 +22,28 @@
     </html:div>
 
     <html:div class="setting-description">
-      Connects the plugin to the indexing and search service. Your administrator
-      will provide you with the server URL and an API key to enter here.
+      Connects the plugin to the indexing and search service.
     </html:div>
 
-    <html:div class="setting-row" id="zotero-rag-api-key-row">
-      <html:label for="zotero-rag-api-key">API Key:</html:label>
-      <html:input id="zotero-rag-api-key"
+    <html:div class="setting-row">
+      <html:label for="zotero-rag-zotero-api-key">Zotero API Key:</html:label>
+      <html:input id="zotero-rag-zotero-api-key"
                   type="password"
-                  placeholder="Enter API Key"
+                  placeholder="Your personal Zotero API key"
                   class="setting-input"/>
     </html:div>
 
-    <html:div class="setting-description" id="zotero-rag-api-key-desc">
-      Needed to access the RAG server.
+    <html:div class="setting-description">
+      Your personal <html:a href="https://www.zotero.org/settings/keys"
+                            target="_blank">Zotero API key</html:a>
+      — used to authenticate you to the server and determine which libraries you can access.
+      Not required when the server runs on your own machine (localhost).
+    </html:div>
+
+    <html:div class="setting-description" id="zotero-rag-zotero-api-key-status"></html:div>
+
+    <html:div class="setting-row">
+      <html:button id="zotero-rag-run-wizard">Run Setup Wizard…</html:button>
     </html:div>
   </html:fieldset>
 
@@ -54,24 +62,13 @@
     <html:legend>Automatic indexing</html:legend>
 
     <html:div class="setting-description">
-      Submit a <html:strong>read-only</html:strong> Zotero API key
-      (create one at <html:a href="https://www.zotero.org/settings/keys"
-                            target="_blank">zotero.org/settings/keys</html:a>)
-      to have your library automatically indexed by the backend on a schedule.
-      Only read-only keys are accepted.
+      Have the backend automatically index your libraries on a schedule, using the Zotero API
+      key configured above.
     </html:div>
 
-    <html:div class="setting-row">
-      <html:label for="zotero-rag-autoindex-key">Read-only API key:</html:label>
-      <html:input id="zotero-rag-autoindex-key"
-                  type="password"
-                  placeholder="Zotero read-only API key"
-                  class="setting-input"/>
-    </html:div>
-
-    <html:div class="setting-row">
-      <html:button id="zotero-rag-autoindex-enable">Enable auto-indexing</html:button>
-      <html:button id="zotero-rag-autoindex-remove">Remove</html:button>
+    <html:div style="display:flex;align-items:center;margin:6px 0 4px 0;">
+      <html:input type="checkbox" id="zotero-rag-autoindex-toggle"/>
+      <html:label for="zotero-rag-autoindex-toggle" style="margin-left:6px;cursor:pointer;">Enable automatic indexing of my libraries</html:label>
     </html:div>
 
     <html:div class="setting-description" id="zotero-rag-autoindex-status"></html:div>

--- a/plugin/src/setup-wizard.js
+++ b/plugin/src/setup-wizard.js
@@ -115,7 +115,8 @@ var ZoteroSetupWizard = {
 				status.className = 'wizard-status status-error';
 				return;
 			}
-			await this.enterKeysStep();
+			const enteredKeysStep = await this.enterKeysStep();
+			if (!enteredKeysStep) return;
 			this.goToStep(2);
 			return;
 		}
@@ -225,19 +226,30 @@ var ZoteroSetupWizard = {
 	/**
 	 * Populate Step 3 (Service API Keys) and, if requested, submit the
 	 * auto-indexing checkbox state before moving on.
-	 * @returns {Promise<void>}
+	 * @returns {Promise<boolean>} False if the auto-indexing submission failed — the
+	 *   caller should stay on the current step and let the user see the error rather
+	 *   than silently proceeding as if it had succeeded.
 	 */
 	async enterKeysStep() {
 		const autoindexCheckbox = /** @type {HTMLInputElement} */ (document.getElementById('wizard-autoindex-checkbox'));
 		if (autoindexCheckbox && autoindexCheckbox.checked && this.plugin.zoteroApiKey) {
+			const status = document.getElementById('wizard-identity-status');
 			try {
-				await fetch(`${this.plugin.backendURL}/api/autoindex/keys`, {
+				const response = await fetch(`${this.plugin.backendURL}/api/autoindex/keys`, {
 					method: 'POST',
 					headers: this.plugin.getAuthHeaders({ 'Content-Type': 'application/json' }),
 					body: JSON.stringify({ api_key: this.plugin.zoteroApiKey }),
 				});
+				if (!response.ok) {
+					const err = await response.json().catch(() => ({}));
+					status.textContent = `Could not enable automatic indexing: ${err.detail || response.status}`;
+					status.className = 'wizard-status status-error';
+					return false;
+				}
 			} catch (e) {
-				console.warn('Failed to enable auto-indexing from wizard: ' + e);
+				status.textContent = `Could not enable automatic indexing: ${e instanceof Error ? e.message : String(e)}`;
+				status.className = 'wizard-status status-error';
+				return false;
 			}
 		}
 
@@ -245,6 +257,7 @@ var ZoteroSetupWizard = {
 		const container = document.getElementById('wizard-service-keys-container');
 		const placeholder = document.getElementById('wizard-service-keys-placeholder');
 		this.plugin.renderServiceApiKeyFields(document, container, placeholder, this.plugin.requiredApiKeys);
+		return true;
 	},
 };
 

--- a/plugin/src/setup-wizard.js
+++ b/plugin/src/setup-wizard.js
@@ -1,0 +1,240 @@
+// @ts-check
+// Dialog controller for the Zotero RAG setup wizard (Server -> Zotero identity -> Service API keys).
+
+;(function() {
+	/** @type {Record<string, number>} */
+	const nsFlags = { warn: 0x1, error: 0x0 };
+	const makeLogger = (/** @type {string} */ level) => (/** @type {any[]} */ ...args) => {
+		const msg = "[Zotero RAG / setup-wizard] " + args.join(" ");
+		if (level === "log" || level === "info") {
+			// @ts-ignore
+			Services.console.logStringMessage(msg);
+		} else {
+			// @ts-ignore
+			const e = Cc["@mozilla.org/scripterror;1"].createInstance(Ci.nsIScriptError);
+			// @ts-ignore
+			e.init(msg, "", null, 0, 0, nsFlags[level], "chrome javascript");
+			// @ts-ignore
+			Services.console.logMessage(e);
+		}
+	};
+	// @ts-ignore
+	if (typeof console === "undefined") {
+		// @ts-ignore
+		globalThis.console = { log: makeLogger("log"), info: makeLogger("info"), warn: makeLogger("warn"), error: makeLogger("error") };
+	} else {
+		["log", "info", "warn", "error"].forEach(level => { /** @type {any} */ (console)[level] = makeLogger(level); });
+	}
+})();
+
+var ZoteroSetupWizard = {
+	/** @type {any} */
+	plugin: null,
+
+	/** @type {string[]} */
+	steps: ['wizard-step-server', 'wizard-step-identity', 'wizard-step-keys'],
+
+	/** @type {number} */
+	currentStep: 0,
+
+	/** @type {boolean} */
+	identityValidated: false,
+
+	/**
+	 * Initialise the dialog. Called automatically after DOMContentLoaded loads this script.
+	 * @returns {void}
+	 */
+	init() {
+		// @ts-ignore - window.arguments is available in XUL/Firefox extension context
+		if (!window.arguments || !window.arguments[0]) {
+			console.error("No arguments passed to setup wizard dialog");
+			return;
+		}
+		// @ts-ignore
+		const args = window.arguments[0];
+		this.plugin = args.plugin;
+
+		const backendUrlInput = /** @type {HTMLInputElement} */ (document.getElementById('wizard-server-url'));
+		backendUrlInput.value = this.plugin.backendURL || '';
+
+		document.getElementById('wizard-cancel-btn').addEventListener('click', () => window.close());
+		document.getElementById('wizard-back-btn').addEventListener('click', () => this.goToStep(this.currentStep - 1));
+		document.getElementById('wizard-next-btn').addEventListener('click', () => this.onNext());
+		document.getElementById('wizard-create-key-btn').addEventListener('click', () => {
+			Zotero.launchURL('https://www.zotero.org/settings/keys/new');
+		});
+		document.getElementById('wizard-validate-btn').addEventListener('click', () => this.validateIdentity());
+
+		// External links inside the wizard (including the dynamically-rendered "Get key"
+		// links for Service API Keys in #wizard-service-keys-container) don't open in the
+		// system browser on their own (target="_blank" is a no-op here). Route http(s)
+		// links through Zotero.launchURL so they open in the user's default browser.
+		// Same pattern as the click handler on #zotero-rag-prefs-container in preferences.js.
+		document.addEventListener('click', (e) => {
+			const anchor = /** @type {Element} */ (e.target)?.closest?.('a[href]');
+			if (!anchor) return;
+			const href = anchor.getAttribute('href');
+			if (href && /^https?:\/\//i.test(href)) {
+				e.preventDefault();
+				Zotero.launchURL(href);
+			}
+		});
+
+		this.goToStep(0);
+	},
+
+	/**
+	 * @param {number} index
+	 * @returns {void}
+	 */
+	goToStep(index) {
+		if (index < 0 || index >= this.steps.length) return;
+		this.currentStep = index;
+		for (let i = 0; i < this.steps.length; i++) {
+			document.getElementById(this.steps[i]).classList.toggle('active', i === index);
+		}
+		const backBtn = /** @type {HTMLButtonElement} */ (document.getElementById('wizard-back-btn'));
+		const nextBtn = /** @type {HTMLButtonElement} */ (document.getElementById('wizard-next-btn'));
+		backBtn.disabled = index === 0;
+		nextBtn.textContent = index === this.steps.length - 1 ? 'Finish' : 'Next';
+	},
+
+	/**
+	 * Handle the Next/Finish button for the current step.
+	 * @returns {Promise<void>}
+	 */
+	async onNext() {
+		if (this.currentStep === 0) {
+			await this.confirmServer();
+			return;
+		}
+		if (this.currentStep === 1) {
+			if (!this.plugin.isLoopbackBackend() && !this.identityValidated) {
+				const status = document.getElementById('wizard-identity-status');
+				status.textContent = 'Please validate your Zotero API key first.';
+				status.className = 'wizard-status status-error';
+				return;
+			}
+			await this.enterKeysStep();
+			this.goToStep(2);
+			return;
+		}
+		// Step 3 (keys): Finish
+		window.close();
+	},
+
+	/**
+	 * Save + ping the server URL, then decide whether Step 2 (Zotero identity)
+	 * is needed, based on whether the URL points at a loopback address.
+	 * @returns {Promise<void>}
+	 */
+	async confirmServer() {
+		const input = /** @type {HTMLInputElement} */ (document.getElementById('wizard-server-url'));
+		const status = document.getElementById('wizard-server-status');
+		const url = input.value.trim().replace(/\/+$/, '');
+		if (!url) {
+			status.textContent = 'Please enter a server URL.';
+			status.className = 'wizard-status status-error';
+			return;
+		}
+		try {
+			new URL(url);
+		} catch (_) {
+			status.textContent = 'That does not look like a valid URL.';
+			status.className = 'wizard-status status-error';
+			return;
+		}
+		status.textContent = 'Checking server...';
+		status.className = 'wizard-status';
+		Zotero.Prefs.set('extensions.zotero-rag.backendURL', url, true);
+		this.plugin.backendURL = url;
+		try {
+			await this.plugin.checkBackendVersion();
+			status.textContent = '';
+		} catch (e) {
+			// @ts-ignore
+			if (e && (e.status === 401 || e.status === 403)) {
+				// Reachable, just not authenticated yet — expected, continue to Step 2.
+				status.textContent = '';
+			} else {
+				status.textContent = `Could not reach server: ${e instanceof Error ? e.message : String(e)}`;
+				status.className = 'wizard-status status-error';
+				return;
+			}
+		}
+
+		const identityIntro = document.getElementById('wizard-identity-intro');
+		const autoindexRow = document.getElementById('wizard-autoindex-row');
+		if (this.plugin.isLoopbackBackend()) {
+			identityIntro.textContent = 'This server runs on your own machine — no Zotero API key is required.';
+			document.getElementById('wizard-create-key-btn').setAttribute('hidden', 'true');
+			document.getElementById('wizard-zotero-key').setAttribute('hidden', 'true');
+			document.getElementById('wizard-validate-btn').setAttribute('hidden', 'true');
+			autoindexRow.style.display = 'none';
+			this.identityValidated = true;
+			this.goToStep(1);
+			await this.enterKeysStep();
+			this.goToStep(2);
+			return;
+		}
+		this.goToStep(1);
+	},
+
+	/**
+	 * Validate the pasted key against the backend without saving it first.
+	 * @returns {Promise<void>}
+	 */
+	async validateIdentity() {
+		const input = /** @type {HTMLInputElement} */ (document.getElementById('wizard-zotero-key'));
+		const status = document.getElementById('wizard-identity-status');
+		const key = input.value.trim();
+		if (!key) {
+			status.textContent = 'Please paste your Zotero API key.';
+			status.className = 'wizard-status status-error';
+			return;
+		}
+		status.textContent = 'Validating...';
+		status.className = 'wizard-status';
+		try {
+			const result = await this.plugin.checkZoteroIdentity(key);
+			Zotero.Prefs.set('extensions.zotero-rag.zoteroApiKey', key, true);
+			this.plugin.zoteroApiKey = key;
+			this.identityValidated = true;
+			const count = Array.isArray(result.targets) ? result.targets.length : 0;
+			status.textContent = `✓ Authenticated as ${result.username} — ${count} librar${count === 1 ? 'y' : 'ies'} accessible.`;
+			status.className = 'wizard-status status-ok';
+			document.getElementById('wizard-autoindex-row').style.display = 'flex';
+		} catch (e) {
+			this.identityValidated = false;
+			status.textContent = e instanceof Error ? e.message : String(e);
+			status.className = 'wizard-status status-error';
+		}
+	},
+
+	/**
+	 * Populate Step 3 (Service API Keys) and, if requested, submit the
+	 * auto-indexing checkbox state before moving on.
+	 * @returns {Promise<void>}
+	 */
+	async enterKeysStep() {
+		const autoindexCheckbox = /** @type {HTMLInputElement} */ (document.getElementById('wizard-autoindex-checkbox'));
+		if (autoindexCheckbox && autoindexCheckbox.checked && this.plugin.zoteroApiKey) {
+			try {
+				await fetch(`${this.plugin.backendURL}/api/autoindex/keys`, {
+					method: 'POST',
+					headers: this.plugin.getAuthHeaders({ 'Content-Type': 'application/json' }),
+					body: JSON.stringify({ api_key: this.plugin.zoteroApiKey }),
+				});
+			} catch (e) {
+				console.warn('Failed to enable auto-indexing from wizard: ' + e);
+			}
+		}
+
+		await this.plugin.fetchRequiredApiKeys();
+		const container = document.getElementById('wizard-service-keys-container');
+		const placeholder = document.getElementById('wizard-service-keys-placeholder');
+		this.plugin.renderServiceApiKeyFields(document, container, placeholder, this.plugin.requiredApiKeys);
+	},
+};
+
+ZoteroSetupWizard.init();

--- a/plugin/src/setup-wizard.js
+++ b/plugin/src/setup-wizard.js
@@ -165,6 +165,17 @@ var ZoteroSetupWizard = {
 
 		const identityIntro = document.getElementById('wizard-identity-intro');
 		const autoindexRow = document.getElementById('wizard-autoindex-row');
+
+		// Reset Step 2 identity UI to its default (non-loopback) state before deciding
+		// again below. Without this, a prior confirmServer() call against a loopback URL
+		// would leave the Zotero API key inputs hidden and identityValidated stuck at
+		// true even after the user goes Back and re-confirms a non-loopback URL.
+		identityIntro.textContent = 'This server requires your personal Zotero API key to authenticate you and determine which libraries you can access.';
+		document.getElementById('wizard-create-key-btn').removeAttribute('hidden');
+		document.getElementById('wizard-zotero-key').removeAttribute('hidden');
+		document.getElementById('wizard-validate-btn').removeAttribute('hidden');
+		this.identityValidated = false;
+
 		if (this.plugin.isLoopbackBackend()) {
 			identityIntro.textContent = 'This server runs on your own machine — no Zotero API key is required.';
 			document.getElementById('wizard-create-key-btn').setAttribute('hidden', 'true');

--- a/plugin/src/setup-wizard.xhtml
+++ b/plugin/src/setup-wizard.xhtml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <title>Zotero RAG Setup Wizard</title>
+  <meta charset="utf-8"/>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      try {
+        Services.scriptloader.loadSubScript("chrome://zotero/content/include.js", window);
+      } catch (e) {
+        console.error("Failed to load include.js:", e);
+      }
+      try {
+        Services.scriptloader.loadSubScript("chrome://zotero-rag/content/setup-wizard.js", window);
+      } catch (e) {
+        console.error("Failed to load setup-wizard.js:", e);
+      }
+    });
+  </script>
+  <style>
+    html, body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 13px; }
+    .wizard-container { display: flex; flex-direction: column; padding: 16px; box-sizing: border-box; }
+    .wizard-step { display: none; }
+    .wizard-step.active { display: block; }
+    .wizard-step p { color: #444; line-height: 1.5; }
+    .wizard-row { display: flex; align-items: center; margin: 10px 0; gap: 8px; }
+    .wizard-row label { min-width: 140px; font-weight: 500; }
+    .wizard-input { flex: 1; padding: 6px 10px; font-size: 13px; border: 1px solid #ccc; border-radius: 4px; font-family: inherit; }
+    .wizard-status { font-size: 12px; margin: 6px 0; min-height: 15px; }
+    .status-ok { color: #006600; }
+    .status-error { color: #cc0000; }
+    .wizard-buttons { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; border-top: 1px solid #ddd; padding-top: 12px; }
+    .wizard-button { padding: 6px 16px; min-height: 30px; border: 1px solid #ccc; border-radius: 4px; background: #f5f5f5; color: #333; cursor: pointer; font-family: inherit; font-size: 13px; }
+    .wizard-button:hover { background: #e5e5e5; }
+    .wizard-button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .wizard-button.primary { background: #0066cc; color: #fff; border-color: #0066cc; }
+    .wizard-button.primary:hover { background: #0052a3; }
+    .wizard-button.primary:disabled { opacity: 0.5; cursor: not-allowed; background: #0066cc; }
+    #wizard-service-keys-container .setting-row { display: flex; align-items: center; margin: 8px 0; gap: 8px; }
+    #wizard-service-keys-container .setting-row label { min-width: 140px; font-weight: 500; }
+    #wizard-service-keys-container .setting-input { flex: 1; padding: 6px 10px; font-size: 13px; border: 1px solid #ccc; border-radius: 4px; font-family: inherit; }
+    #wizard-service-keys-container .setting-description { font-size: 12px; color: #666; margin: 4px 0 8px; }
+  </style>
+</head>
+
+<body>
+  <div class="wizard-container">
+
+    <!-- Step 1: Server -->
+    <div class="wizard-step active" id="wizard-step-server">
+      <h3>Server</h3>
+      <p>Enter the address of your Zotero RAG backend server.</p>
+      <div class="wizard-row">
+        <label for="wizard-server-url">Server URL:</label>
+        <input id="wizard-server-url" type="text" class="wizard-input" placeholder="http://localhost:8119"/>
+      </div>
+      <div class="wizard-status" id="wizard-server-status"></div>
+    </div>
+
+    <!-- Step 2: Zotero identity -->
+    <div class="wizard-step" id="wizard-step-identity">
+      <h3>Zotero Account</h3>
+      <p id="wizard-identity-intro">
+        This server requires your personal Zotero API key to authenticate you and determine
+        which libraries you can access.
+      </p>
+      <div class="wizard-row">
+        <button type="button" class="wizard-button" id="wizard-create-key-btn">Create key on zotero.org</button>
+      </div>
+      <div class="wizard-row">
+        <label for="wizard-zotero-key">Zotero API Key:</label>
+        <input id="wizard-zotero-key" type="password" class="wizard-input" placeholder="Paste your key here"/>
+        <button type="button" class="wizard-button" id="wizard-validate-btn">Validate</button>
+      </div>
+      <div class="wizard-status" id="wizard-identity-status"></div>
+      <div class="wizard-row" id="wizard-autoindex-row" style="display:none;">
+        <input type="checkbox" id="wizard-autoindex-checkbox"/>
+        <label for="wizard-autoindex-checkbox" style="min-width:auto;cursor:pointer;">Also enable automatic indexing of these libraries</label>
+      </div>
+    </div>
+
+    <!-- Step 3: Service API Keys -->
+    <div class="wizard-step" id="wizard-step-keys">
+      <h3>Service API Keys</h3>
+      <p id="wizard-keys-intro">These API keys are required by the backend's current configuration.</p>
+      <div id="wizard-service-keys-container">
+        <div class="setting-description" id="wizard-service-keys-placeholder">
+          No API keys required for this backend configuration.
+        </div>
+      </div>
+    </div>
+
+    <div class="wizard-buttons">
+      <button type="button" class="wizard-button" id="wizard-cancel-btn">Cancel</button>
+      <button type="button" class="wizard-button" id="wizard-back-btn" disabled="true">Back</button>
+      <button type="button" class="wizard-button primary" id="wizard-next-btn">Next</button>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/plugin/src/zotero-rag.js
+++ b/plugin/src/zotero-rag.js
@@ -537,7 +537,13 @@ class ZoteroRAGPlugin {
 	 * Render service API key input fields into `container`, one row + description
 	 * per required key, each bound to `extensions.zotero-rag.serviceApiKey.<key_name>`.
 	 * Shared between the Preferences pane and the setup wizard so both stay in sync.
-	 * @param {Document} doc
+	 *
+	 * Note: generated "Get key" links use `target="_blank"`, which is a no-op in a
+	 * privileged Zotero document. The caller must provide its own delegated
+	 * `a[href]` → `Zotero.launchURL` click handler over (or containing) `container`
+	 * so these links actually open in the system browser — see the click handler
+	 * on `#zotero-rag-prefs-container` in `preferences.js` for the pattern.
+	 * @param {Document} doc - Document to create elements in (the Preferences pane document, or a dialog document)
 	 * @param {HTMLElement} container - Element to render rows into (existing dynamic rows are cleared first)
 	 * @param {HTMLElement|null} placeholder - Shown/hidden depending on whether requiredKeys is empty
 	 * @param {Array<{key_name: string, header_name: string, description: string, docs_url?: string|null, required_for: string[]}>} requiredKeys

--- a/plugin/src/zotero-rag.js
+++ b/plugin/src/zotero-rag.js
@@ -104,7 +104,10 @@ class ZoteroRAGPlugin {
 		this.backendURL = null;
 
 		/** @type {string} */
-		this.apiKey = '';
+		this.zoteroApiKey = '';
+
+		/** @type {boolean} */
+		this._wizardAutoLaunchedThisSession = false;
 
 		/** @type {Set<string>} */
 		this.activeQueries = new Set();
@@ -168,8 +171,8 @@ class ZoteroRAGPlugin {
 		// Load backend URL from preferences (default: localhost:8119)
 		this.backendURL = (Zotero.Prefs.get('extensions.zotero-rag.backendURL', true) || 'http://localhost:8119').replace(/\/+$/, '');
 
-		// Load optional API key (required when backend is on a remote host)
-		this.apiKey = Zotero.Prefs.get('extensions.zotero-rag.apiKey', true) || '';
+		// Load the personal Zotero API key (required when backend is on a remote host)
+		this.zoteroApiKey = Zotero.Prefs.get('extensions.zotero-rag.zoteroApiKey', true) || '';
 
 		// Load cached required API keys list (refreshed on each successful backend connection)
 		try {
@@ -199,15 +202,15 @@ class ZoteroRAGPlugin {
 
 	/**
 	 * Return HTTP headers to include in all backend requests.
-	 * Adds X-API-Key when an API key is configured.
+	 * Adds X-Zotero-API-Key when a personal Zotero API key is configured.
 	 * @param {Record<string, string>} [extra] - Additional headers to merge
 	 * @returns {Record<string, string>}
 	 */
 	getAuthHeaders(extra = {}) {
 		/** @type {Record<string, string>} */
 		const headers = { ...extra };
-		if (this.apiKey) {
-			headers['X-API-Key'] = this.apiKey;
+		if (this.zoteroApiKey) {
+			headers['X-Zotero-API-Key'] = this.zoteroApiKey;
 		}
 		// Include any service API keys the user has configured
 		for (const keyInfo of this.requiredApiKeys) {
@@ -218,15 +221,39 @@ class ZoteroRAGPlugin {
 	}
 
 	/**
-	 * Append the API key as a query parameter to a URL.
-	 * Used for SSE (EventSource) endpoints that cannot set request headers.
-	 * @param {string} url - Base URL
-	 * @returns {string} URL with api_key appended when configured
+	 * True if the configured backend URL points at a loopback address, where
+	 * the backend skips Zotero-key auth entirely (single trusted local user).
+	 * @returns {boolean}
 	 */
-	addApiKeyParam(url) {
-		if (!this.apiKey) return url;
-		const sep = url.includes('?') ? '&' : '?';
-		return `${url}${sep}api_key=${encodeURIComponent(this.apiKey)}`;
+	isLoopbackBackend() {
+		try {
+			const host = new URL(this.backendURL).hostname;
+			return host === 'localhost' || host === '127.0.0.1';
+		} catch (_) {
+			return false;
+		}
+	}
+
+	/**
+	 * Validate a Zotero API key against the backend and return the caller's
+	 * identity. Does not read or write any pref — callers pass the candidate
+	 * key explicitly so it can be checked before being saved.
+	 * @param {string} candidateKey
+	 * @returns {Promise<{authorized: true, loopback: boolean, user_id?: number, username?: string, targets?: string[]}>}
+	 * @throws {Error} with a `status` property set to the HTTP status code, and
+	 *   a message taken from the response's `detail` field, on 401/403/503.
+	 */
+	async checkZoteroIdentity(candidateKey) {
+		const response = await fetch(`${this.backendURL}/api/auth/whoami`, {
+			headers: candidateKey ? { 'X-Zotero-API-Key': candidateKey } : {},
+		});
+		if (!response.ok) {
+			const body = await response.json().catch(() => ({}));
+			const err = /** @type {Error & {status?: number}} */ (new Error(body.detail || `HTTP ${response.status}`));
+			err.status = response.status;
+			throw err;
+		}
+		return response.json();
 	}
 
 	/**
@@ -435,32 +462,39 @@ class ZoteroRAGPlugin {
 	/**
 	 * Check backend version for compatibility.
 	 * @returns {Promise<string>} Backend version string
-	 * @throws {Error} If backend is not reachable or returns error
+	 * @throws {Error & {status?: number}} If backend is not reachable or returns error.
+	 *   `status` is set to the HTTP status code when the server responded (e.g. 401/403),
+	 *   and left undefined for network-level failures (server unreachable).
 	 */
 	async checkBackendVersion() {
 		if (!this.backendURL) {
 			throw new Error('Backend URL not configured');
 		}
 
+		let response;
 		try {
-			const response = await fetch(`${this.backendURL}/api/version`, {
+			response = await fetch(`${this.backendURL}/api/version`, {
 				headers: this.getAuthHeaders()
 			});
-			if (!response.ok) {
-				const body = await response.json().catch(() => ({}));
-				throw new Error(`GET /api/version: HTTP ${response.status}${body.detail ? ` — ${body.detail}` : ''}`);
-			}
-			const data = /** @type {BackendVersion} */ (await response.json());
-			this.log(`Backend version: ${data.api_version}`);
-
-			// TODO: Add version compatibility checking
-			// Refresh the list of required API keys from the server
-			await this.fetchRequiredApiKeys();
-			return data.api_version;
 		} catch (e) {
 			const errorMessage = e instanceof Error ? e.message : String(e);
 			throw new Error(`Failed to check backend version: ${errorMessage}`);
 		}
+		if (!response.ok) {
+			const body = await response.json().catch(() => ({}));
+			const err = /** @type {Error & {status?: number}} */ (
+				new Error(`GET /api/version: HTTP ${response.status}${body.detail ? ` — ${body.detail}` : ''}`)
+			);
+			err.status = response.status;
+			throw err;
+		}
+		const data = /** @type {BackendVersion} */ (await response.json());
+		this.log(`Backend version: ${data.api_version}`);
+
+		// TODO: Add version compatibility checking
+		// Refresh the list of required API keys from the server
+		await this.fetchRequiredApiKeys();
+		return data.api_version;
 	}
 
 	/**
@@ -488,10 +522,7 @@ class ZoteroRAGPlugin {
 	async fetchRequiredApiKeys() {
 		try {
 			const resp = await fetch(`${this.backendURL}/api/required-keys`, {
-				headers: {
-					'Content-Type': 'application/json',
-					...(this.apiKey ? { 'X-API-Key': this.apiKey } : {}),
-				},
+				headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
 			});
 			if (!resp.ok) return;
 			const data = await resp.json();

--- a/plugin/src/zotero-rag.js
+++ b/plugin/src/zotero-rag.js
@@ -451,6 +451,13 @@ class ZoteroRAGPlugin {
 		} catch (e) {
 			const errorMessage = e instanceof Error ? e.message : String(e);
 			this.log(`Backend not available: ${errorMessage}`);
+			// @ts-ignore
+			const status = e && e.status;
+			if ((status === 401 || status === 403) && !this.isLoopbackBackend() && !this._wizardAutoLaunchedThisSession) {
+				this._wizardAutoLaunchedThisSession = true;
+				const win = Zotero.getMainWindow();
+				if (win) this.openSetupWizard(win);
+			}
 			return;
 		}
 

--- a/plugin/src/zotero-rag.js
+++ b/plugin/src/zotero-rag.js
@@ -534,6 +534,69 @@ class ZoteroRAGPlugin {
 	}
 
 	/**
+	 * Render service API key input fields into `container`, one row + description
+	 * per required key, each bound to `extensions.zotero-rag.serviceApiKey.<key_name>`.
+	 * Shared between the Preferences pane and the setup wizard so both stay in sync.
+	 * @param {Document} doc
+	 * @param {HTMLElement} container - Element to render rows into (existing dynamic rows are cleared first)
+	 * @param {HTMLElement|null} placeholder - Shown/hidden depending on whether requiredKeys is empty
+	 * @param {Array<{key_name: string, header_name: string, description: string, docs_url?: string|null, required_for: string[]}>} requiredKeys
+	 * @returns {void}
+	 */
+	renderServiceApiKeyFields(doc, container, placeholder, requiredKeys) {
+		if (!container) return;
+
+		container.querySelectorAll('.service-key-row, .service-key-desc').forEach(el => el.remove());
+
+		if (!requiredKeys || requiredKeys.length === 0) {
+			if (placeholder) placeholder.style.display = '';
+			return;
+		}
+		if (placeholder) placeholder.style.display = 'none';
+
+		for (const keyInfo of requiredKeys) {
+			const prefKey = `extensions.zotero-rag.serviceApiKey.${keyInfo.key_name}`;
+			const storedValue = Zotero.Prefs.get(prefKey, true) || '';
+
+			const row = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+			row.className = 'setting-row service-key-row';
+
+			const label = doc.createElementNS('http://www.w3.org/1999/xhtml', 'label');
+			label.textContent = `${keyInfo.key_name}:`;
+			label.setAttribute('for', `zotero-rag-key-${keyInfo.key_name}`);
+
+			const input = /** @type {HTMLInputElement} */ (doc.createElementNS('http://www.w3.org/1999/xhtml', 'input'));
+			input.type = 'password';
+			input.id = `zotero-rag-key-${keyInfo.key_name}`;
+			input.className = 'setting-input';
+			input.value = storedValue;
+			input.placeholder = 'Enter API key';
+			input.addEventListener('change', (e) => {
+				Zotero.Prefs.set(prefKey, /** @type {HTMLInputElement} */ (e.target).value, true);
+			});
+
+			row.appendChild(label);
+			row.appendChild(input);
+			container.appendChild(row);
+
+			if (keyInfo.description) {
+				const desc = doc.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+				desc.className = 'setting-description service-key-desc';
+				desc.textContent = `${keyInfo.description} (used for: ${keyInfo.required_for.join(', ')})`;
+				if (keyInfo.docs_url && /^https?:\/\//i.test(keyInfo.docs_url)) {
+					desc.appendChild(doc.createTextNode(' '));
+					const link = doc.createElementNS('http://www.w3.org/1999/xhtml', 'a');
+					link.setAttribute('href', keyInfo.docs_url);
+					link.setAttribute('target', '_blank');
+					link.textContent = 'Get key';
+					desc.appendChild(link);
+				}
+				container.appendChild(desc);
+			}
+		}
+	}
+
+	/**
 	 * Open the query dialog.
 	 * @param {Window} window - Parent window
 	 * @returns {Promise<void>}

--- a/plugin/src/zotero-rag.js
+++ b/plugin/src/zotero-rag.js
@@ -134,6 +134,9 @@ class ZoteroRAGPlugin {
 		/** @type {Window|null} */
 		this._dialogWindow = null;
 
+		/** @type {Window|null} */
+		this._setupWizardWindow = null;
+
 		/** @type {string|null} */
 		this._notifierID = null;
 
@@ -1701,6 +1704,26 @@ class ZoteroRAGPlugin {
 			'zotero-rag-fix-unavailable',
 			'chrome,centerscreen,resizable=yes,width=720,height=560',
 			{ plugin: this, libraryID: zoteroLibraryID, backendLibraryId }
+		);
+	}
+
+	/**
+	 * Open the setup wizard (Server -> Zotero identity -> Service API keys).
+	 * Focuses the existing dialog instead of opening a second one if already open.
+	 * @param {Window} win - Parent window
+	 * @returns {void}
+	 */
+	openSetupWizard(win) {
+		if (this._setupWizardWindow && !this._setupWizardWindow.closed) {
+			this._setupWizardWindow.focus();
+			return;
+		}
+		// @ts-ignore - openDialog is available in XUL/Firefox extension context
+		this._setupWizardWindow = win.openDialog(
+			'chrome://zotero-rag/content/setup-wizard.xhtml',
+			'zotero-rag-setup-wizard',
+			'chrome,centerscreen,resizable=yes,width=520,height=480',
+			{ plugin: this }
 		);
 	}
 

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -121,18 +121,22 @@ def find_plugin_process():
     return None
 
 
-def extract_error_from_log():
-    """Extract user-friendly error message from log file.
+def extract_error_from_log(log_file=None):
+    """Extract user-friendly error message from a log file.
+
+    Args:
+        log_file: Path to the log file to search. Defaults to the backend LOG_FILE.
 
     Returns:
         Error message string if found, None otherwise
     """
-    if not LOG_FILE.exists():
+    log_file = log_file or LOG_FILE
+    if not log_file.exists():
         return None
 
     try:
         # Read the last 100 lines of the log
-        with open(LOG_FILE, 'r', encoding='utf-8') as f:
+        with open(log_file, 'r', encoding='utf-8', errors='ignore') as f:
             lines = f.readlines()
             recent_lines = lines[-100:] if len(lines) > 100 else lines
 
@@ -164,6 +168,19 @@ def extract_error_from_log():
                     if lines_in_block and '=' in lines_in_block[0]:
                         lines_in_block = lines_in_block[1:]
                     return '\n'.join(lines_in_block).strip()
+
+        # Fallback: our own scripts print "[ERROR] ..." followed by "[INFO] ..."
+        # lines explaining the cause/fix (e.g. missing dependency, missing binary).
+        # Grab that contiguous block starting at the last such [ERROR] line.
+        for i in range(len(recent_lines) - 1, -1, -1):
+            if '[ERROR]' in recent_lines[i]:
+                block = recent_lines[i:i + 10]
+                trimmed = []
+                for bline in block:
+                    if not bline.strip() and trimmed:
+                        break
+                    trimmed.append(bline.rstrip('\n'))
+                return '\n'.join(trimmed).strip()
 
         # Fallback: look for ERROR: messages in recent lines
         for line in reversed(recent_lines):
@@ -513,7 +530,11 @@ def _start_plugin_server_and_wait():
     print("Waiting for plugin server to start...")
     if not wait_for_plugin_startup(timeout=60):
         print("[ERROR] Plugin server failed to start within timeout")
-        print(f"[INFO] Check logs at: {PLUGIN_LOG_FILE}")
+        error_msg = extract_error_from_log(PLUGIN_LOG_FILE)
+        if error_msg:
+            print("\n" + error_msg)
+        else:
+            print(f"[INFO] Check logs at: {PLUGIN_LOG_FILE}")
         stop_plugin_server()
         sys.exit(1)
 
@@ -677,7 +698,11 @@ def start_server(dev_mode=True, with_plugin=False):
                     sys.exit(1)
             else:
                 print("[ERROR] Server failed to start")
-                print(f"Check logs at: {LOG_FILE}")
+                error_msg = extract_error_from_log()
+                if error_msg:
+                    print("\n" + error_msg)
+                else:
+                    print(f"Check logs at: {LOG_FILE}")
                 sys.exit(1)
 
     except Exception as e:
@@ -812,7 +837,11 @@ def start_plugin_server():
             return _plugin_process
         else:
             print("[ERROR] Plugin server failed to start")
-            print(f"Check logs at: {PLUGIN_LOG_FILE}")
+            error_msg = extract_error_from_log(PLUGIN_LOG_FILE)
+            if error_msg:
+                print("\n" + error_msg)
+            else:
+                print(f"Check logs at: {PLUGIN_LOG_FILE}")
             cleanup_plugin_processes()
             return None
 


### PR DESCRIPTION
## Summary

Replaces the backend's single shared `X-API-Key` secret with per-user Zotero.org authentication end to end, closing an IDOR where any caller with the shared key could read/delete any other user's library.

- **Backend identity & access gate:** every request's Zotero API key resolves to `(user_id, username, targets)` via `api.zotero.org` (cached with a TTL); every library-scoped endpoint enforces `library_id ∈ targets`. An access gate (group membership and/or an explicit user-id allowlist) controls who may use a remote instance at all. Loopback deployments are exempt (single trusted local user).
- **Plugin:** sends `X-Zotero-API-Key` instead of the old shared secret. A new 3-step setup wizard (Server → Zotero identity → Service API keys) obtains and validates the key via `GET /api/auth/whoami`, and auto-launches on a 401/403 startup failure. The Preferences pane gained a "Zotero API Key" field with live validation and a "Run Setup Wizard…" button; automatic indexing collapsed to a single on/off toggle reusing that same key (no separate credential).
- **Cutover:** the transitional shared-secret fallback is fully removed (single-operator deployment, no staged migration window needed).

Design docs: `docs/history/plan-zotero-key-auth.md` (backend identity/gate) and `docs/superpowers/specs/2026-07-06-zotero-key-auth-plugin-wizard-design.md` (plugin wizard + cutover), with the corresponding implementation plans under `docs/superpowers/plans/`.

## Test plan

- [x] `uv run pytest backend/tests/ -v` — 409 passed, 17 skipped (unrelated environment-dependent tests), 0 failed
- [x] `node --check` on every touched plugin `.js` file
- [x] Manual verification in a live Zotero instance (via the MCP Zotero bridge): Preferences pane renders the new Zotero API Key field, correct loopback status message, Service API Keys section, and auto-index toggle; "Run Setup Wizard…" opens the dialog, correctly skips the Zotero-identity step for a loopback backend, and its "Get key" links route through `Zotero.launchURL`
- [x] Two bugs found live during manual verification were fixed and re-verified: the auto-index toggle being enabled with no key configured on loopback, and the wizard silently swallowing a failed auto-index enrollment
- [ ] The non-loopback 401/403 → auto-launch-wizard path requires a remote/gated deployment and hasn't been exercised against a real one yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)